### PR TITLE
New function params from reviewer comments, documentation updates

### DIFF
--- a/R/build_era5_request.R
+++ b/R/build_era5_request.R
@@ -20,7 +20,10 @@
 #' are required.
 #' @param end_time a POSIXlt object indicating the last hour for which data
 #' are required.
-#' @param outfile_name character prefix for .nc files when downloaded.
+#' @param outfile_name character prefix for .nc files when downloaded (the year and file extension is automatically added). Keep in
+#' mind that you may want to submit multiple (or many) requests, and therefore
+#' this prefix should adequately describe a unique query (e.g. by its
+#' spatial or temporal extent).
 #'
 #' @export
 #'

--- a/R/extract_clim.R
+++ b/R/extract_clim.R
@@ -28,7 +28,23 @@
 #' correction. Default = 1.
 #'
 #' @return a data frame containing hourly values for a suite of climate
-#' variables.
+#' variables:
+#' obs_time | the date-time (timezone specified in col timezone)
+#' temperature | (degrees celsius)
+#' humidity | specific humidity (kg / kg)
+#' pressure | (Pa)
+#' windspeed | (m / s)
+#' winddir | wind direction, azimuth (degrees from north)
+#' emissivity | downward long wave radiation flux divided by the sum of net long-wave radiation flux and downward long wave radiation flux (unitless)
+#' cloudcover | %
+#' netlong | Net longwave radiation (MJ / m2 / hr)
+#' uplong | Upward longwave radiation (MJ / m2 / hr)
+#' downlong | Downward longwave radiation (MJ / m2 / hr)
+#' rad_dni | Direct normal irradiance (MJ / m2 / hr)
+#' rad_dif | Diffuse normal irradiance (MJ / m2 / hr)
+#' szenith | Solar zenith angle (degrees from a horizontal plane)
+#' timezone (unitless)
+#'
 #' @export
 #'
 #' @examples

--- a/R/extract_clim.R
+++ b/R/extract_clim.R
@@ -28,22 +28,22 @@
 #' correction. Default = 1.
 #'
 #' @return a data frame containing hourly values for a suite of climate
-#' variables:
-#' obs_time | the date-time (timezone specified in col timezone)
-#' temperature | (degrees celsius)
-#' humidity | specific humidity (kg / kg)
-#' pressure | (Pa)
-#' windspeed | (m / s)
-#' winddir | wind direction, azimuth (degrees from north)
-#' emissivity | downward long wave radiation flux divided by the sum of net long-wave radiation flux and downward long wave radiation flux (unitless)
-#' cloudcover | %
-#' netlong | Net longwave radiation (MJ / m2 / hr)
-#' uplong | Upward longwave radiation (MJ / m2 / hr)
-#' downlong | Downward longwave radiation (MJ / m2 / hr)
-#' rad_dni | Direct normal irradiance (MJ / m2 / hr)
-#' rad_dif | Diffuse normal irradiance (MJ / m2 / hr)
-#' szenith | Solar zenith angle (degrees from a horizontal plane)
-#' timezone (unitless)
+#' variables:\cr
+#' obs_time | the date-time (timezone specified in col timezone)\cr
+#' temperature | (degrees celsius)\cr
+#' humidity | specific humidity (kg / kg)\cr
+#' pressure | (Pa)\cr
+#' windspeed | (m / s)\cr
+#' winddir | wind direction, azimuth (degrees from north)\cr
+#' emissivity | downward long wave radiation flux divided by the sum of net long-wave radiation flux and downward long wave radiation flux (unitless)\cr
+#' cloudcover | (%)\cr
+#' netlong | Net longwave radiation (MJ / m2 / hr)\cr
+#' uplong | Upward longwave radiation (MJ / m2 / hr)\cr
+#' downlong | Downward longwave radiation (MJ / m2 / hr)\cr
+#' rad_dni | Direct normal irradiance (MJ / m2 / hr)\cr
+#' rad_dif | Diffuse normal irradiance (MJ / m2 / hr)\cr
+#' szenith | Solar zenith angle (degrees from a horizontal plane)\cr
+#' timezone (unitless)\cr
 #'
 #' @export
 #'

--- a/R/extract_clim.R
+++ b/R/extract_clim.R
@@ -27,23 +27,23 @@
 #' @param dtr_cor_fac numeric value to be used in the diurnal temperature range
 #' correction. Default = 1.
 #'
-#' @return a data frame containing hourly values for a suite of climate
-#' variables:\cr
-#' obs_time | the date-time (timezone specified in col timezone)\cr
-#' temperature | (degrees celsius)\cr
-#' humidity | specific humidity (kg / kg)\cr
-#' pressure | (Pa)\cr
-#' windspeed | (m / s)\cr
-#' winddir | wind direction, azimuth (degrees from north)\cr
-#' emissivity | downward long wave radiation flux divided by the sum of net long-wave radiation flux and downward long wave radiation flux (unitless)\cr
-#' cloudcover | (%)\cr
-#' netlong | Net longwave radiation (MJ / m2 / hr)\cr
-#' uplong | Upward longwave radiation (MJ / m2 / hr)\cr
-#' downlong | Downward longwave radiation (MJ / m2 / hr)\cr
-#' rad_dni | Direct normal irradiance (MJ / m2 / hr)\cr
-#' rad_dif | Diffuse normal irradiance (MJ / m2 / hr)\cr
-#' szenith | Solar zenith angle (degrees from a horizontal plane)\cr
-#' timezone (unitless)\cr
+#' @return a data frame containing hourly values for a suite of climate variables:
+#' @return `obs_time` | the date-time (timezone specified in col timezone)
+#' @return `temperature` | (degrees celsius)
+#' @return `humidity` | specific humidity (kg / kg)
+#' @return `pressure` | (Pa)
+#' @return `windspeed` | (m / s)
+#' @return `winddir` | wind direction, azimuth (degrees from north)
+#' @return `emissivity` | downward long wave radiation flux divided by the sum
+#' of net long-wave radiation flux and downward long wave radiation flux (unitless)
+#' @return `cloudcover` | (%)
+#' @return `netlong` | Net longwave radiation (MJ / m2 / hr)
+#' @return `uplong` | Upward longwave radiation (MJ / m2 / hr)
+#' @return `downlong` | Downward longwave radiation (MJ / m2 / hr)
+#' @return `rad_dni` | Direct normal irradiance (MJ / m2 / hr)
+#' @return `rad_dif` | Diffuse normal irradiance (MJ / m2 / hr)
+#' @return `szenith` | Solar zenith angle (degrees from a horizontal plane)
+#' @return `timezone` | (unitless)
 #'
 #' @export
 #'

--- a/R/extract_precip.R
+++ b/R/extract_precip.R
@@ -1,10 +1,10 @@
-#' Produces daily precipitation data for a single location ready for use
+#' Produces daily or hourly precipitation data for a single location ready for use
 #' with `microclima::runauto`.
 #'
 #' @description `extract_precip` takes an nc file containing hourly ERA5
 #' climate data, and for a given set of coordinates, produces an (optionally)
-#' inverse distance weighted mean of daily precipitation, ready for
-#' use with `microclima::runauto`.
+#' inverse distance weighted mean of precipitation (at daily or hourly resolution)
+#' ready for use with `microclima::runauto`.
 #'
 #' @param nc character vector containing the path to the nc file. Use the
 #' `build_era5_request` and `request_era5` functions to acquire an nc file with
@@ -21,14 +21,17 @@
 #' @param d_weight logical value indicating whether to apply inverse distance
 #' weighting using the 4 closest neighbouring points to the location defined by
 #' `long` and `lat`. Default = `TRUE`.
+#' @param convert_daily a flag indicating whether the user desires to convert the
+#' precipitation vector from hourly to daily averages (TRUE) or remain as hourly
+#' values (FALSE). Only daily precipitation will be accepted by `microclima::runauto`.
 #'
-#' @return a numeric vector of daily precipitation (mm).
+#' @return a numeric vector of daily or hourly precipitation (mm).
 #' @export
 #'
 #' @examples
 #'
 extract_precip <- function(nc, long, lat, start_time, end_time,
-                                  d_weight = TRUE) {
+                                  d_weight = TRUE, convert_daily = TRUE) {
 
   if(sum((long %% .25) + (lat %% .25)) == 0 & d_weight == TRUE) {
     message("Input coordinates match ERA5 grid, no distance weighting required.")
@@ -64,8 +67,12 @@ extract_precip <- function(nc, long, lat, start_time, end_time,
   }
 
   # convert to daily
-  daily_p <- matrix(dat,ncol=24,byrow=T) %>%
-    rowSums() * 1000
+  if (convert_daily) {
+    precip <- matrix(dat,ncol=24,byrow=T) %>%
+      rowSums() * 1000
+  } else {
+    precip <- dat
+  }
 
-  return(daily_p)
+  return(precip)
 }

--- a/R/request_era5.R
+++ b/R/request_era5.R
@@ -6,13 +6,23 @@
 #' @param request a list of request(s) created with `build_era5_request`.
 #' @param uid character vector containing your CDS user ID.
 #' @param out_path character vector of the location at which to download nc files.
+#' @param overwrite TRUE for overwriting a file of the same path. Default FALSE.
 #'
 #' @export
 #'
 #'
-request_era5 <- function(request, uid, out_path) {
+request_era5 <- function(request, uid, out_path, overwrite = FALSE) {
 
   for(req in 1:length(request)) {
+
+    # Check whether file already exists for requested out_path
+    if (file.exists(paste0(out_path, "/", request[[req]]$target)) & !overwrite) {
+      if (length(request) > 1) {
+        stop("Filename already exists within requested out_path in request ", req, " of request series. Use overwrite = TRUE if you wish to overwrite this file.")
+      } else {
+        stop("Filename already exists within requested out_path. Use overwrite = TRUE if you wish to overwrite this file.")
+      }
+    }
 
     ecmwfr::wf_request(user = as.character(uid),
                        request = request[[req]],
@@ -20,5 +30,13 @@ request_era5 <- function(request, uid, out_path) {
                        path = out_path,
                        verbose = TRUE,
                        time_out = 18000)
+
+    if (file.exists(paste0(out_path, "/", request[[req]]$target))) {
+      if (length(request) > 1) {
+        cat("ERA5 netCDF file", req, "successfully downloaded.\n")
+      } else {
+        cat("ERA5 netCDF file successfully downloaded.\n")
+      }
+    }
   }
 }

--- a/R/request_era5.R
+++ b/R/request_era5.R
@@ -11,8 +11,12 @@
 #' @export
 #'
 #'
-request_era5 <- function(request, uid, out_path, overwrite = FALSE) {
+request_era5 <- function(request, uid, out_path, overwrite = FALSE,
+                         combine = FALSE) {
 
+  if (length(request) == 1 & combine) {
+    cat("Your request will all be queried at once and does not need to be combined.\n")
+  }
   for(req in 1:length(request)) {
 
     # Check whether file already exists for requested out_path
@@ -38,5 +42,12 @@ request_era5 <- function(request, uid, out_path, overwrite = FALSE) {
         cat("ERA5 netCDF file successfully downloaded.\n")
       }
     }
+  }
+  if (length(request) > 1 & combine) {
+    cat("Now combining netCDF files...\n")
+    # Get list of filenames
+    fnames <- lapply(request, function(x) {x$target})
+    combine_netcdf(filenames = fnames, combined_name = "combined.nc")
+    cat("Finished.\n")
   }
 }

--- a/R/request_era5.R
+++ b/R/request_era5.R
@@ -7,6 +7,7 @@
 #' @param uid character vector containing your CDS user ID.
 #' @param out_path character vector of the location at which to download nc files.
 #' @param overwrite TRUE for overwriting a file of the same path. Default FALSE.
+#' @param combine TRUE for combining downloaded annual files into one file. Default FALSE.
 #'
 #' @export
 #'

--- a/man/build_era5_request.Rd
+++ b/man/build_era5_request.Rd
@@ -30,7 +30,10 @@ are required.}
 \item{end_time}{a POSIXlt object indicating the last hour for which data
 are required.}
 
-\item{outfile_name}{character prefix for .nc files when downloaded.}
+\item{outfile_name}{character prefix for .nc files when downloaded (the year and file extension is automatically added). Keep in
+mind that you may want to submit multiple (or many) requests, and therefore
+this prefix should adequately describe a unique query (e.g. by its
+spatial or temporal extent).}
 }
 \description{
 `build_era5_request` creates a request or set of requests that

--- a/man/extract_clim.Rd
+++ b/man/extract_clim.Rd
@@ -45,23 +45,38 @@ range correction to air temperature values. Default = `TRUE`.}
 correction. Default = 1.}
 }
 \value{
-a data frame containing hourly values for a suite of climate
-variables:\cr
-obs_time | the date-time (timezone specified in col timezone)\cr
-temperature | (degrees celsius)\cr
-humidity | specific humidity (kg / kg)\cr
-pressure | (Pa)\cr
-windspeed | (m / s)\cr
-winddir | wind direction, azimuth (degrees from north)\cr
-emissivity | downward long wave radiation flux divided by the sum of net long-wave radiation flux and downward long wave radiation flux (unitless)\cr
-cloudcover | (%)\cr
-netlong | Net longwave radiation (MJ / m2 / hr)\cr
-uplong | Upward longwave radiation (MJ / m2 / hr)\cr
-downlong | Downward longwave radiation (MJ / m2 / hr)\cr
-rad_dni | Direct normal irradiance (MJ / m2 / hr)\cr
-rad_dif | Diffuse normal irradiance (MJ / m2 / hr)\cr
-szenith | Solar zenith angle (degrees from a horizontal plane)\cr
-timezone (unitless)\cr
+a data frame containing hourly values for a suite of climate variables:
+
+`obs_time` | the date-time (timezone specified in col timezone)
+
+`temperature` | (degrees celsius)
+
+`humidity` | specific humidity (kg / kg)
+
+`pressure` | (Pa)
+
+`windspeed` | (m / s)
+
+`winddir` | wind direction, azimuth (degrees from north)
+
+`emissivity` | downward long wave radiation flux divided by the sum
+of net long-wave radiation flux and downward long wave radiation flux (unitless)
+
+`cloudcover` | (%)
+
+`netlong` | Net longwave radiation (MJ / m2 / hr)
+
+`uplong` | Upward longwave radiation (MJ / m2 / hr)
+
+`downlong` | Downward longwave radiation (MJ / m2 / hr)
+
+`rad_dni` | Direct normal irradiance (MJ / m2 / hr)
+
+`rad_dif` | Diffuse normal irradiance (MJ / m2 / hr)
+
+`szenith` | Solar zenith angle (degrees from a horizontal plane)
+
+`timezone` | (unitless)
 }
 \description{
 `extract_clim` takes an nc file containing hourly ERA5 climate

--- a/man/extract_clim.Rd
+++ b/man/extract_clim.Rd
@@ -46,22 +46,22 @@ correction. Default = 1.}
 }
 \value{
 a data frame containing hourly values for a suite of climate
-variables:
-obs_time | the date-time (timezone specified in col timezone)
-temperature | (degrees celsius)
-humidity | specific humidity (kg / kg)
-pressure | (Pa)
-windspeed | (m / s)
-winddir | wind direction, azimuth (degrees from north)
-emissivity | downward long wave radiation flux divided by the sum of net long-wave radiation flux and downward long wave radiation flux (unitless)
-cloudcover | %
-netlong | Net longwave radiation (MJ / m2 / hr)
-uplong | Upward longwave radiation (MJ / m2 / hr)
-downlong | Downward longwave radiation (MJ / m2 / hr)
-rad_dni | Direct normal irradiance (MJ / m2 / hr)
-rad_dif | Diffuse normal irradiance (MJ / m2 / hr)
-szenith | Solar zenith angle (degrees from a horizontal plane)
-timezone (unitless)
+variables:\cr
+obs_time | the date-time (timezone specified in col timezone)\cr
+temperature | (degrees celsius)\cr
+humidity | specific humidity (kg / kg)\cr
+pressure | (Pa)\cr
+windspeed | (m / s)\cr
+winddir | wind direction, azimuth (degrees from north)\cr
+emissivity | downward long wave radiation flux divided by the sum of net long-wave radiation flux and downward long wave radiation flux (unitless)\cr
+cloudcover | (%)\cr
+netlong | Net longwave radiation (MJ / m2 / hr)\cr
+uplong | Upward longwave radiation (MJ / m2 / hr)\cr
+downlong | Downward longwave radiation (MJ / m2 / hr)\cr
+rad_dni | Direct normal irradiance (MJ / m2 / hr)\cr
+rad_dif | Diffuse normal irradiance (MJ / m2 / hr)\cr
+szenith | Solar zenith angle (degrees from a horizontal plane)\cr
+timezone (unitless)\cr
 }
 \description{
 `extract_clim` takes an nc file containing hourly ERA5 climate

--- a/man/extract_clim.Rd
+++ b/man/extract_clim.Rd
@@ -46,7 +46,22 @@ correction. Default = 1.}
 }
 \value{
 a data frame containing hourly values for a suite of climate
-variables.
+variables:
+obs_time | the date-time (timezone specified in col timezone)
+temperature | (degrees celsius)
+humidity | specific humidity (kg / kg)
+pressure | (Pa)
+windspeed | (m / s)
+winddir | wind direction, azimuth (degrees from north)
+emissivity | downward long wave radiation flux divided by the sum of net long-wave radiation flux and downward long wave radiation flux (unitless)
+cloudcover | %
+netlong | Net longwave radiation (MJ / m2 / hr)
+uplong | Upward longwave radiation (MJ / m2 / hr)
+downlong | Downward longwave radiation (MJ / m2 / hr)
+rad_dni | Direct normal irradiance (MJ / m2 / hr)
+rad_dif | Diffuse normal irradiance (MJ / m2 / hr)
+szenith | Solar zenith angle (degrees from a horizontal plane)
+timezone (unitless)
 }
 \description{
 `extract_clim` takes an nc file containing hourly ERA5 climate

--- a/man/extract_precip.Rd
+++ b/man/extract_precip.Rd
@@ -2,10 +2,18 @@
 % Please edit documentation in R/extract_precip.R
 \name{extract_precip}
 \alias{extract_precip}
-\title{Produces daily precipitation data for a single location ready for use
+\title{Produces daily or hourly precipitation data for a single location ready for use
 with `microclima::runauto`.}
 \usage{
-extract_precip(nc, long, lat, start_time, end_time, d_weight = TRUE)
+extract_precip(
+  nc,
+  long,
+  lat,
+  start_time,
+  end_time,
+  d_weight = TRUE,
+  convert_daily = TRUE
+)
 }
 \arguments{
 \item{nc}{character vector containing the path to the nc file. Use the
@@ -28,15 +36,19 @@ are required.}
 \item{d_weight}{logical value indicating whether to apply inverse distance
 weighting using the 4 closest neighbouring points to the location defined by
 `long` and `lat`. Default = `TRUE`.}
+
+\item{convert_daily}{a flag indicating whether the user desires to convert the
+precipitation vector from hourly to daily averages (TRUE) or remain as hourly
+values (FALSE). Only daily precipitation will be accepted by `microclima::runauto`.}
 }
 \value{
-a numeric vector of daily precipitation (mm).
+a numeric vector of daily or hourly precipitation (mm).
 }
 \description{
 `extract_precip` takes an nc file containing hourly ERA5
 climate data, and for a given set of coordinates, produces an (optionally)
-inverse distance weighted mean of daily precipitation, ready for
-use with `microclima::runauto`.
+inverse distance weighted mean of precipitation (at daily or hourly resolution)
+ready for use with `microclima::runauto`.
 }
 \examples{
 

--- a/man/request_era5.Rd
+++ b/man/request_era5.Rd
@@ -14,6 +14,8 @@ request_era5(request, uid, out_path, overwrite = FALSE, combine = FALSE)
 \item{out_path}{character vector of the location at which to download nc files.}
 
 \item{overwrite}{TRUE for overwriting a file of the same path. Default FALSE.}
+
+\item{combine}{TRUE for combining downloaded annual files into one file. Default FALSE.}
 }
 \description{
 Uses the `ecwmfr` package to submit requests to the Climate

--- a/man/request_era5.Rd
+++ b/man/request_era5.Rd
@@ -4,7 +4,7 @@
 \alias{request_era5}
 \title{Submit request(s) to CDS for ERA5 data download}
 \usage{
-request_era5(request, uid, out_path)
+request_era5(request, uid, out_path, overwrite = FALSE, combine = FALSE)
 }
 \arguments{
 \item{request}{a list of request(s) created with `build_era5_request`.}
@@ -12,6 +12,8 @@ request_era5(request, uid, out_path)
 \item{uid}{character vector containing your CDS user ID.}
 
 \item{out_path}{character vector of the location at which to download nc files.}
+
+\item{overwrite}{TRUE for overwriting a file of the same path. Default FALSE.}
 }
 \description{
 Uses the `ecwmfr` package to submit requests to the Climate

--- a/vignettes/mcera5_vignette.Rmd
+++ b/vignettes/mcera5_vignette.Rmd
@@ -25,7 +25,9 @@ The following packages are required:
 ```{r packages, warning = FALSE, message = FALSE}
 library(dplyr)
 library(ecmwfr)
+library(ncdf4)
 library(keyring)
+library(abind)
 library(lubridate)
 library(tidync)
 library(microclima) # remotes::install_github("ilyamaclean/microclima")
@@ -79,8 +81,9 @@ ymx <- 51
 st_time <- lubridate::ymd("2010:02:26")
 en_time <- lubridate::ymd("2010:03:01")
 
-# filename and location for downloaded .nc files
-file_prefix <- "era5_test"
+# Set a unique prefix for the filename, and the file path for 
+# downloaded .nc files
+file_prefix <- "era5"
 op <- "C:/Sandbox"
 
 # build a request (covering multiple years)
@@ -115,25 +118,27 @@ Once all .nc files are downloaded, the next step is to extract climate variables
 my_nc <- "C:/Sandbox/era5_test_2010.nc"
 
 # for a single point (make sure it's within the bounds of your .nc file)
-long <- -3.654600
-lat <- 50.640369
+x <- -3.654600
+y <- 50.640369
 
 # gather all hourly variables
-point_out <- extract_clim(nc = my_nc, x = long, y = lat,
+point_out <- extract_clim(nc = my_nc, long = x, lat = y,
                             start_time = st_time,  end_time = en_time)
 head(point_out)
 
-# gather daily precipitation
-point_out_precip <- extract_precip(nc = my_nc, x = long, y = lat,
-                                          start_time = st_time,  
-                                          end_time = en_time)
+# gather daily precipitation (we specify to convert precipitation from hourly
+# to daily, which is already the default behavior)
+point_out_precip <- extract_precip(nc = my_nc, long = x, lat = y,
+                                   start_time = st_time,  
+                                   end_time = en_time,
+                                   convert_daily = TRUE)
 ```
 
 The dataframe created by `extract_clim` and vector created by `extract_precip` are ready to be used as inputs to the `runauto` function from the `microclima` package:
 
 ```{r runauto_example, eval = FALSE}
 # create a 200 x 200 30 m spatial resoltuion DEM for location
-r <- microclima::get_dem(lat = lat, long = long, resolution = 30)
+r <- microclima::get_dem(lat = y, long = x, resolution = 30)
 
 # change date format to fit runauto requirements
 temps <- microclima::runauto(r = r, dstart = "26/02/2010",dfinish = "01/03/2010", 

--- a/vignettes/mcera5_vignette.Rmd
+++ b/vignettes/mcera5_vignette.Rmd
@@ -26,12 +26,14 @@ The following packages are required:
 library(dplyr)
 library(ecmwfr)
 library(ncdf4)
+library(curl)
 library(keyring)
 library(abind)
 library(lubridate)
 library(tidync)
 library(microclima) # remotes::install_github("ilyamaclean/microclima")
 library(NicheMapR) # remotes::install_github("mrke/NicheMapR")
+library(mcera5)
 ```
 
 ```{r funs, include = FALSE}
@@ -60,12 +62,10 @@ ecmwfr::wf_set_key(user = uid,
 #### Building a request
 
 The first step is to decide on the spatial and temporal extents of the data retrieved from the CDS.
-There is a fair sized overhead in submitting a request (and consequently waiting in a queue) so it 
-is sensible to execute as few requests as possible. To this end, it is recommended to ensure the 
-spatial extent covers multiple areas of interest (within reason) and that the temporal extent covers
-multiple time periods of interest.
 
-Requests are submitted as whole months, and also they will be split by year, so that they are not too big to handle. The splitting of requests which overlap year boundaries is dealt with automatically. 
+There can overhead time of several hours for downloading data from the CDS, even for small amounts of data (<10 MB). Such overhead time is independent of mcera5, and is due to the slow speed of querying archival CDS data as well as based upon current CDS activity and the spatial/temporal dimensions of the query. Generally, querying temporal durations greater than one year causes a delay, while query of wide spatial extents can occur rapidly. It is therefore most efficient to download time series data in temporal chunks (e.g. monthly basis) each specifying a region encompassing multiple points of interest. We recommend users track current usage of the CDS at https://cds.climate.copernicus.eu/live/queue and ECMWF news (such as the migration of the MARS Data Centre between November 2021 and April 2022) at https://confluence.ecmwf.int/#all-updates.
+
+Requests are submitted as whole months, and they will also be split by year, so that they are not too big to handle and to expedite wait times. The splitting of requests which overlap year boundaries is dealt with automatically. Users can request files to be merged together in the `request_era5()` function (covered later on). 
 
 Once these parameters are decided, one can begin to build the request(s) as follows:
 
@@ -83,8 +83,8 @@ en_time <- lubridate::ymd("2010:03:01")
 
 # Set a unique prefix for the filename, and the file path for 
 # downloaded .nc files
-file_prefix <- "era5"
-op <- "C:/Sandbox"
+file_prefix <- "era5_-4_-2_49_51"
+op <- getwd()
 
 # build a request (covering multiple years)
 req <- build_era5_request(xmin = xmn, xmax = xmx, 
@@ -103,7 +103,7 @@ str(req)
 
 #### Obtaining data with a request
 
-The next step is to execute the requests, by sending them to the CDS. The `request_era5` function will deal with lists containing multiple requests (i.e. those created by `build_era5_request` with temporal extents spanning multiple years). Executing `request_era5` will download .nc files for each year to the location defined by `out_path`. The filenames will have a prefix defined by `outfile_name` in `build_era5_request`:
+The next step is to execute the requests, by sending them to the CDS. The `request_era5` function will deal with lists containing multiple requests (i.e. those created by `build_era5_request` with temporal extents spanning multiple years). Executing `request_era5` will download .nc files for each year to the location defined by `out_path`. The filenames will have a prefix defined by `outfile_name` in `build_era5_request`, followed by the year of the request (for each year of the desired duration). If multiple years are requested and `combine` = TRUE, the files are merged after downloading:  
 
 ```{r send_request, eval = FALSE}
 request_era5(request = req, uid = uid, out_path = op)
@@ -111,11 +111,11 @@ request_era5(request = req, uid = uid, out_path = op)
 
 #### Processing .nc files
 
-Once all .nc files are downloaded, the next step is to extract climate variables conforming to desired spatial and temporal extents from them. This can be done for a single point in space with `extract_clim`. The function outputs a dataframe where each row is a single observation in time and space and each column is a climatic variable. Note that this function uses the same start and end times defined prior to building the request. Furthermore, the function (by default) uses the land-sea mask data (automatically downloaded alongside climate variables with `request_era5`), to filter out points that do not meet a land-sea threshold. 0 represents complete sea, and 1 complete land. By default, the threshold is liberally set to 0.05. Given that `runauto` in the `microclima` package only accepts date ranges within single years, you will need to create a data frame for each yearly block. For example, if your period of interest spans multiple years (and you have used the previous code to download multiple .nc files, run this next block of code for each year):
+Once all .nc files are downloaded, the next step is to extract climate variables conforming to desired spatial and temporal extents from them. This can be done for a single point in space with `extract_clim`. The function outputs a dataframe where each row is a single observation in time and space and each column is a climatic variable. Note that this function uses the same start and end times defined prior to building the request. Furthermore, the function (by default) uses the land-sea mask data (automatically downloaded alongside climate variables with `request_era5`), to filter out points that do not meet a land-sea threshold. 0 represents complete sea, and 1 complete land. By default, the threshold is liberally set to 0.05. Given that `runauto` in the `microclima` package only accepts date ranges within single years, you will need to create a data frame for each yearly block. For example, if your period of interest spans multiple years (and you have used the previous code to download multiple .nc files, it is recommended to run this next block of code for each year)  
 
 ```{r process_nc, eval = FALSE}
 # list the path of the .nc file for a given year
-my_nc <- "C:/Sandbox/era5_test_2010.nc"
+my_nc <- paste0(getwd(), "/era5_test_-4_-2_49_51.nc")
 
 # for a single point (make sure it's within the bounds of your .nc file)
 x <- -3.654600


### PR DESCRIPTION
Set of commits stemming from addressing reviewer comments and improving modularity while I was at it.  

Highlights:  

- users can specify whether they wish to combine multiple downloaded netCDF files (one for each year) into one file
- users can specify if they want the hourly precip values rather than the (default) daily sum
- checks whether user will overwrite a file with a new query and will stop them unless they specify `overwrite = TRUE`
- updating the vignette to reflect these changes, and some adjusts and improves of function documentation