### PR TITLE
Change to monthly ERA5 requests and added ERA5-Land support

### DIFF
--- a/R/build_era5_land_request.R
+++ b/R/build_era5_land_request.R
@@ -1,0 +1,88 @@
+#' Builds a request compatible with the CDS for all microclimate relevant climate
+#' variables of ERA5-Land.
+#'
+#' @description `build_era5_request` creates a request or set of requests of ERA5-Land data that
+#' can be submitted to the Climate Data Store (CDS) with the `ecmwfr` package.
+#' Spatial and temporal extents are defined by the user, and requests are
+#' automatically split by month. The following variables are requested:
+#' 2m_temperature, 2m_dewpoint_temperature, surface_pressure,
+#' 10m_u_component_of_wind, 10m_v_component_of_wind, total_precipitation.
+#'
+#' @param xmin The minimum longitude to request data for.
+#' @param xmax The maximum longitude to request data for.
+#' @param ymin The minimum latitude to request data for.
+#' @param ymax The maximum latitude to request data for.
+#' @param start_time a POSIXlt object indicating the first hour for which data
+#' are required.
+#' @param end_time a POSIXlt object indicating the last hour for which data
+#' are required.
+#' @param outfile_name character prefix for .nc files when downloaded (the year, month, and file extension is automatically added). Keep in
+#' mind that you may want to submit multiple (or many) requests, and therefore
+#' this prefix should adequately describe a unique query (e.g. by its
+#' spatial or temporal extent).
+#'
+#' @export
+#'
+#'
+build_era5_land_request <- function(xmin, xmax, ymin, ymax, start_time, end_time,
+                                    outfile_name = "era5_land_out") {
+  # input checks
+  if (missing(xmin)) {
+    stop("xmin is missing")
+  }
+  if (missing(xmax)) {
+    stop("xmax is missing")
+  }
+  if (missing(ymin)) {
+    stop("ymin is missing")
+  }
+  if (missing(ymax)) {
+    stop("ymax is missing")
+  }
+  if (missing(start_time)) {
+    stop("start_time is missing")
+  }
+  if (missing(end_time)) {
+    stop("end_time is missing")
+  }
+
+  # round to regular grid
+  xmin_r <- plyr::round_any(xmin, .1, f = floor)
+  xmax_r <- plyr::round_any(xmax, .1, f = ceiling)
+  ymin_r <- plyr::round_any(ymin, .1, f = floor)
+  ymax_r <- plyr::round_any(ymax, .1, f = ceiling)
+  # area of interest
+  ar <- paste0(ymax_r, "/", xmin_r, "/", ymin_r, "/", xmax_r)
+  # month/year combos
+  ut <- uni_dates(start_time, end_time)
+
+  # iterate over all focal months
+  request <- apply(ut, 1, function(time) {
+    list(
+      "dataset_short_name" = "reanalysis-era5-land",
+      "product_type" = "reanalysis",
+      "variable" = c("2m_temperature", "2m_dewpoint_temperature", "surface_pressure",
+                     "10m_u_component_of_wind", "10m_v_component_of_wind", "total_precipitation"),
+      "year" = as.character(time[2]),
+      "month" = as.character(time[1]),
+      "day" = c(
+        "01", "02", "03", "04", "05", "06", "07", "08", "09", "10", "11",
+        "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22",
+        "23", "24", "25", "26", "27", "28", "29", "30", "31"
+      ),
+      "time" = c(
+        "00:00", "01:00", "02:00", "03:00", "04:00", "05:00", "06:00",
+        "07:00", "08:00", "09:00", "10:00", "11:00", "12:00", "13:00",
+        "14:00", "15:00", "16:00", "17:00", "18:00", "19:00", "20:00",
+        "21:00", "22:00", "23:00"
+      ),
+      "area" = ar,
+      "format" = "netcdf",
+      # "format" = "grib",
+      "target" = paste0(outfile_name, "_", time[2], "_", time[1], ".nc")
+      # "target" = paste0(outfile_name, "_", time[2], "_", time[1], ".grib")
+    )
+  })
+
+  return(request)
+}

--- a/R/build_era5_land_request.R
+++ b/R/build_era5_land_request.R
@@ -61,8 +61,11 @@ build_era5_land_request <- function(xmin, xmax, ymin, ymax, start_time, end_time
     list(
       "dataset_short_name" = "reanalysis-era5-land",
       "product_type" = "reanalysis",
-      "variable" = c("2m_temperature", "2m_dewpoint_temperature", "surface_pressure",
-                     "10m_u_component_of_wind", "10m_v_component_of_wind", "total_precipitation"),
+      "variable" = c(
+        "2m_temperature", "2m_dewpoint_temperature", "surface_pressure",
+        "10m_u_component_of_wind", "10m_v_component_of_wind", "total_precipitation",
+        "surface_solar_radiation_downwards"
+      ),
       "year" = as.character(time[2]),
       "month" = as.character(time[1]),
       "day" = c(
@@ -78,9 +81,7 @@ build_era5_land_request <- function(xmin, xmax, ymin, ymax, start_time, end_time
       ),
       "area" = ar,
       "format" = "netcdf",
-      # "format" = "grib",
       "target" = paste0(outfile_name, "_", time[2], "_", time[1], ".nc")
-      # "target" = paste0(outfile_name, "_", time[2], "_", time[1], ".grib")
     )
   })
 

--- a/R/build_era5_request.R
+++ b/R/build_era5_request.R
@@ -4,7 +4,7 @@
 #' @description `build_era5_request` creates a request or set of requests that
 #' can be submitted to the Climate Data Store (CDS) with the `ecmwfr` package.
 #' Spatial and temporal extents are defined by the user, and requests are
-#' automatically split by year. The following variables are requested:
+#' automatically split by month. The following variables are requested:
 #' 2m_temperature, 2m_dewpoint_temperature, surface_pressure,
 #' 10m_u_component_of_wind, 10m_v_component_of_wind, total_precipitation,
 #' total_cloud_cover, mean_surface_net_long_wave_radiation_flux,
@@ -20,7 +20,7 @@
 #' are required.
 #' @param end_time a POSIXlt object indicating the last hour for which data
 #' are required.
-#' @param outfile_name character prefix for .nc files when downloaded (the year and file extension is automatically added). Keep in
+#' @param outfile_name character prefix for .nc files when downloaded (the year, month, and file extension is automatically added). Keep in
 #' mind that you may want to submit multiple (or many) requests, and therefore
 #' this prefix should adequately describe a unique query (e.g. by its
 #' spatial or temporal extent).
@@ -30,14 +30,25 @@
 #'
 build_era5_request <- function(xmin, xmax, ymin, ymax, start_time, end_time,
                                outfile_name = "era5_out") {
-
   # input checks
-  if(missing(xmin)) { stop("xmin is missing")}
-  if(missing(xmax)) { stop("xmax is missing")}
-  if(missing(ymin)) { stop("ymin is missing")}
-  if(missing(ymax)) { stop("ymax is missing")}
-  if(missing(start_time)) { stop("start_time is missing")}
-  if(missing(end_time)) { stop("end_time is missing")}
+  if (missing(xmin)) {
+    stop("xmin is missing")
+  }
+  if (missing(xmax)) {
+    stop("xmax is missing")
+  }
+  if (missing(ymin)) {
+    stop("ymin is missing")
+  }
+  if (missing(ymax)) {
+    stop("ymax is missing")
+  }
+  if (missing(start_time)) {
+    stop("start_time is missing")
+  }
+  if (missing(end_time)) {
+    stop("end_time is missing")
+  }
 
   # round to regular grid
   xmin_r <- plyr::round_any(xmin, .25, f = floor)
@@ -45,44 +56,43 @@ build_era5_request <- function(xmin, xmax, ymin, ymax, start_time, end_time,
   ymin_r <- plyr::round_any(ymin, .25, f = floor)
   ymax_r <- plyr::round_any(ymax, .25, f = ceiling)
   # area of interest
-  ar <- paste0(ymax_r,"/",xmin_r,"/",ymin_r,"/",xmax_r)
+  ar <- paste0(ymax_r, "/", xmin_r, "/", ymin_r, "/", xmax_r)
   # month/year combos
   ut <- uni_dates(start_time, end_time)
-  request <- list()
 
-  # loop through focal years
-  for(i in 1:length(unique(ut$yea))) {
-
-    # focal year
-    yr <- unique(ut$yea)[i]
-    # select months relevant to focal year
-    sub_mon <- ut %>%
-      dplyr::filter(., yea == yr) %>%
-      dplyr::select(., mon)
-
-    sub_request <- list(
+  # iterate over all focal months
+  request <- apply(ut, 1, function(time) {
+    list(
       "dataset_short_name" = "reanalysis-era5-single-levels",
       "product_type" = "reanalysis",
-      "variable" = c("2m_temperature", "2m_dewpoint_temperature", "surface_pressure",
-                     "10m_u_component_of_wind", "10m_v_component_of_wind",
-                     "total_precipitation", "total_cloud_cover",
-                     "mean_surface_net_long_wave_radiation_flux",
-                     "mean_surface_downward_long_wave_radiation_flux",
-                     "total_sky_direct_solar_radiation_at_surface",
-                     "surface_solar_radiation_downwards", "land_sea_mask"),
-      "year" = as.character(yr),
-      "month" = as.character(sub_mon$mon),
-      "day" = c("01", "02", "03", "04", "05", "06", "07", "08", "09", "10", "11",
-                "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22",
-                "23", "24", "25", "26", "27", "28", "29", "30", "31"),
-      "time" = c("00:00", "01:00", "02:00", "03:00", "04:00", "05:00", "06:00",
-                 "07:00", "08:00", "09:00", "10:00", "11:00", "12:00", "13:00",
-                 "14:00", "15:00", "16:00", "17:00", "18:00", "19:00", "20:00",
-                 "21:00", "22:00", "23:00"),
+      "variable" = c(
+        "2m_temperature", "2m_dewpoint_temperature", "surface_pressure",
+        "10m_u_component_of_wind", "10m_v_component_of_wind",
+        "total_precipitation", "total_cloud_cover",
+        "mean_surface_net_long_wave_radiation_flux",
+        "mean_surface_downward_long_wave_radiation_flux",
+        "total_sky_direct_solar_radiation_at_surface",
+        "surface_solar_radiation_downwards", "land_sea_mask"
+      ),
+      "year" = as.character(time[2]),
+      "month" = as.character(time[1]),
+      "day" = c(
+        "01", "02", "03", "04", "05", "06", "07", "08", "09", "10", "11",
+        "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22",
+        "23", "24", "25", "26", "27", "28", "29", "30", "31"
+      ),
+      "time" = c(
+        "00:00", "01:00", "02:00", "03:00", "04:00", "05:00", "06:00",
+        "07:00", "08:00", "09:00", "10:00", "11:00", "12:00", "13:00",
+        "14:00", "15:00", "16:00", "17:00", "18:00", "19:00", "20:00",
+        "21:00", "22:00", "23:00"
+      ),
       "area" = ar,
       "format" = "netcdf",
-      "target" = paste0(outfile_name,"_",yr,".nc"))
-    request[[i]] <- sub_request
-  }
+      "target" = paste0(outfile_name, "_", time[2], "_", time[1], ".nc")
+    )
+  })
+
   return(request)
 }
+

--- a/R/extract_land_clim.R
+++ b/R/extract_land_clim.R
@@ -1,0 +1,149 @@
+#' Produces hourly data of ERA5-Land for a single location
+#'
+#' @description `extract_clim` takes an nc file containing hourly ERA5-Land climate
+#' data, and for a given set of coordinates, produces an (optionally) inverse
+#' distance weighted mean of each variable.
+#'
+#' @param nc character vector containing the path to the nc file. Use the
+#' `build_era5_land_request` and `request_era5` functions to acquire an nc file with
+#' the correct set of variables. Data within nc file must span the period
+#' defined by start_time and end_time.
+#' @param long longitude of the location for which data are required (decimal
+#' degrees, -ve west of Greenwich Meridian).
+#' @param lat latitude of the location for which data are required (decimal
+#' degrees, -ve south of the equator).
+#' @param start_time a POSIXlt or POSIXct object indicating the first day or hour
+#' for which data are required. Encouraged to specify desired timezone as UTC (ERA5
+#' data are in UTC by default), but any timezone is accepted.
+#' @param end_time a POSIXlt or POSIXct object indicating the last day or hour for
+#' which data are required. Encouraged to specify desired timezone as UTC (ERA5
+#' data are in UTC by default), but any timezone is accepted.
+#' @param d_weight logical value indicating whether to apply inverse distance
+#' weighting using the 4 closest neighbouring points to the location defined by
+#' `long` and `lat`. Default = `TRUE`.
+#'
+#' @return a data frame containing hourly values for a suite of climate variables:
+#' @return `obs_time` | the date-time (timezone specified in col timezone)
+#' @return `temperature` | (degrees celsius)
+#' @return `humidity` | specific humidity (kg / kg)
+#' @return `pressure` | (Pa)
+#' @return `windspeed` | (m / s)
+#' @return `winddir` | wind direction, azimuth (degrees from north)
+#' @return `szenith` | Solar zenith angle (degrees from a horizontal plane)
+#' @return `timezone` | (unitless)
+#'
+#' @export
+#'
+#'
+
+extract_land_clim <- function(nc, long, lat, start_time, end_time, d_weight = TRUE) {
+
+  # Open nc file for error trapping
+  nc_dat <- ncdf4::nc_open(nc)
+
+  ## Error trapping
+
+  # Confirm that start_time and end_time are date-time objects
+  if (any(!class(start_time) %in% c("Date", "POSIXct", "POSIXt", "POSIXlt")) |
+    any(!class(end_time) %in% c("Date", "POSIXct", "POSIXt", "POSIXlt"))) {
+    stop("`start_time` and `end_time` must be provided as date-time objects.")
+  }
+  # Confirm that start_time and end_time are same class of date-time objects
+  if (any(class(start_time) != class(end_time))) {
+    stop("`start_time` and `end_time` must be of the same date-time class.")
+  }
+
+  # Check if start_time is after first time observation
+  start <- lubridate::ymd_hms("1900:01:01 00:00:00") + (nc_dat$dim$time$vals[1] * 3600)
+  if (start_time < start) {
+    stop("Requested start time is before the beginning of time series of the ERA5 netCDF.")
+  }
+
+  # Check if end_time is before last time observation
+  end <- lubridate::ymd_hms("1900:01:01 00:00:00") + (utils::tail(nc_dat$dim$time$vals, n = 1) * 3600)
+  if (end_time > end) {
+    stop("Requested end time is after the end of time series of the ERA5 netCDF.")
+  }
+
+  # Check if requested coordinates are in spatial grid
+  if (long < min(nc_dat$dim$longitude$vals) | long > max(nc_dat$dim$longitude$vals)) {
+    long_out <- TRUE
+  } else {
+    long_out <- FALSE
+  }
+
+  if (lat < min(nc_dat$dim$latitude$vals) | lat > max(nc_dat$dim$latitude$vals)) {
+    lat_out <- TRUE
+  } else {
+    lat_out <- FALSE
+  }
+
+  # close nc file
+  ncdf4::nc_close(nc_dat)
+
+  if (long_out & lat_out) {
+    stop("Requested coordinates are not represented in the ERA5 netCDF (both longitude and latitude out of range).")
+  }
+  if (long_out) {
+    stop("Requested coordinates are not represented in the ERA5 netCDF (longitude out of range).")
+  }
+  if (lat_out) {
+    stop("Requested coordinates are not represented in the ERA5 netCDF (latitude out of range).")
+  }
+
+  if (lubridate::tz(start_time) != lubridate::tz(end_time)) {
+    stop("start_time and end_time are not in the same timezone.")
+  }
+
+  if (lubridate::tz(start_time) != "UTC" | lubridate::tz(end_time) != "UTC") {
+    warning("provided times (start_time and end_time) are not in timezone UTC (default timezone of ERA5 data). Output will be provided in timezone UTC however.")
+  }
+
+  # Specify hour of end_time as last hour of day, if not specified
+  if (lubridate::hour(end_time) == 0) {
+    end_time <- as.POSIXlt(paste0(
+      lubridate::year(end_time), "-",
+      lubridate::month(end_time), "-",
+      lubridate::day(end_time),
+      " 23:00"
+    ), tz = lubridate::tz(end_time))
+  }
+
+  if (sum((long %% .1) + (lat %% .1)) == 0 & d_weight == TRUE) {
+    message("Input coordinates match ERA5 grid, no distance weighting required.")
+    d_weight <- FALSE
+  }
+
+  # no distance weighting
+  if (d_weight == FALSE) {
+    long <- plyr::round_any(long, 0.1)
+    lat <- plyr::round_any(lat, 0.1)
+    dat <- nc_to_df_land(nc, long, lat, start_time, end_time)
+    message("No distance weighting applied, nearest point used.")
+  }
+  # yes distance weighting
+  if (d_weight == TRUE) {
+    focal <- focal_dist(long, lat, margin = .1)
+    # collector per weighted neighbour
+    focal_collect <- list()
+    for (j in 1:nrow(focal)) {
+      # applies DTR correction if TRUE
+      f_dat <- nc_to_df_land(nc, focal$x[j], focal$y[j], start_time, end_time) %>%
+        dplyr::mutate(inverse_weight = focal$inverse_weight[j])
+      focal_collect[[j]] <- f_dat
+    }
+    # create single weighted dataframe
+    dat <- dplyr::bind_rows(focal_collect, .id = "neighbour") %>%
+      dplyr::group_by(obs_time) %>%
+      dplyr::summarise_at(
+        dplyr::vars(
+          temperature, humidity, pressure, windspeed, winddir, szenith
+        ),
+        weighted.mean,
+        w = dplyr::quo(inverse_weight)
+      ) %>%
+      dplyr::mutate(timezone = lubridate::tz(obs_time))
+    message("Distance weighting applied.")
+  }
+  return(dat)
+}

--- a/R/extract_land_clim.R
+++ b/R/extract_land_clim.R
@@ -37,7 +37,6 @@
 #'
 
 extract_land_clim <- function(nc, long, lat, start_time, end_time, d_weight = TRUE) {
-
   # Open nc file for error trapping
   nc_dat <- ncdf4::nc_open(nc)
 

--- a/R/internal.R
+++ b/R/internal.R
@@ -5,12 +5,12 @@
 #' @return specific humidity (Kg/Kg)
 #' @noRd
 humfromdew <- function(tdew, tc, p) {
-  pk <- p/1000
+  pk <- p / 1000
   ea <- 0.6108 * exp(17.27 * tdew / (tdew + 237.3))
-  e0 <- 0.6108 * exp(17.27 * tc/(tc + 237.3))
-  s <- 0.622 * e0/pk
-  hr <- (ea/e0) * 100
-  hs <- (hr/100) * s
+  e0 <- 0.6108 * exp(17.27 * tc / (tc + 237.3))
+  s <- 0.622 * e0 / pk
+  hr <- (ea / e0) * 100
+  hs <- (hr / 100) * s
   hs
 }
 
@@ -24,10 +24,14 @@ humfromdew <- function(tdew, tc, p) {
 #' @return air temperature (°C)
 #' @noRd
 coastal_correct <- function(tc, tme, landprop, cor_fac = 1.285) {
-  tcdf <- data.frame(tc = tc,
-                     tme = tme) %>%
-    dplyr::mutate(yday = lubridate::yday(tme),
-           year = lubridate::year(tme))
+  tcdf <- data.frame(
+    tc = tc,
+    tme = tme
+  ) %>%
+    dplyr::mutate(
+      yday = lubridate::yday(tme),
+      year = lubridate::year(tme)
+    )
   # Group by yday and year.....
   tcdf <- tcdf %>%
     dplyr::group_by(year, yday) %>%
@@ -55,7 +59,6 @@ coastal_correct <- function(tc, tme, landprop, cor_fac = 1.285) {
 #' @return vector of radiation
 #' @noRd
 rad_calc <- function(rad, tme, long, lat) {
-
   bound <- function(x, mn = 0, mx = 1) {
     x[x > mx] <- mx
     x[x < mn] <- mn
@@ -63,21 +66,28 @@ rad_calc <- function(rad, tme, long, lat) {
   }
   tme1h <- as.POSIXlt(tme, tz = "UTC", origin = "1970-01-01 00:00")
   # interpolate times to 10 mins
-  tme10min <- as.POSIXlt(seq(from = as.POSIXlt(tme1h[1]-3600),
-                             to = as.POSIXlt(tme1h[length(tme1h)]),
-                             by = "10 min"), origin = "1970-01-01 00:00",
-                         tz = "UTC")
-  csr10min <- clearskyrad(tme10min, lat = lat , long = long,
-                                      merid = 0, dst = 0)
+  tme10min <- as.POSIXlt(
+    seq(
+      from = as.POSIXlt(tme1h[1] - 3600),
+      to = as.POSIXlt(tme1h[length(tme1h)]),
+      by = "10 min"
+    ),
+    origin = "1970-01-01 00:00",
+    tz = "UTC"
+  )
+  csr10min <- clearskyrad(tme10min,
+    lat = lat, long = long,
+    merid = 0, dst = 0
+  )
   # mean csr per hour (every 6 values)
   csr1h <- tibble::tibble(csr10min) %>%
-    dplyr::group_by(group = gl(length(csr10min)/6, 6)) %>%
+    dplyr::group_by(group = gl(length(csr10min) / 6, 6)) %>%
     dplyr::summarize(csr1h = mean(csr10min)) %>%
     .$csr1h
   # watch out for NAs here - need modding?
   od <- bound(rad / csr1h)
-  #if (is.na(od)[1]) od[1] <- mean(od, na.rm = T)
-  #if (is.na(od)[length(od)]) od[length(od)] <- mean(od, na.rm = T)
+  # if (is.na(od)[1]) od[1] <- mean(od, na.rm = T)
+  # if (is.na(od)[length(od)]) od[length(od)] <- mean(od, na.rm = T)
   od[is.na(od)] <- 0
   # hourly time stamps on the half hour
   tme1h_2 <- as.POSIXlt(tme1h - 1800, tz = "UTC", origin = "1970-01-01 00:00")
@@ -86,7 +96,7 @@ rad_calc <- function(rad, tme, long, lat) {
   # work out od values for every half hour
   od1h <- stats::spline(tme1h_2, od, n = n)$y
   # select just the ones on the hour
-  od1h <- od1h[seq(2,length(od1h),2)]
+  od1h <- od1h[seq(2, length(od1h), 2)]
   # csr on the hour
   csr1h_2 <- clearskyrad(tme1h, lat = lat, long = long, merid = 0, dst = 0)
   # calculate corrected rad on the hour
@@ -103,26 +113,27 @@ rad_calc <- function(rad, tme, long, lat) {
 #' each neighbouring point
 #' @noRd
 focal_dist <- function(long, lat) {
-
   # round to nearest 0.25
   x_r <- plyr::round_any(long, .25)
   y_r <- plyr::round_any(lat, .25)
   # work out locations of the four neighbour points in the ERA5 dataset
-  if(long >= x_r) {
-    focal_x <- c(x_r, x_r, x_r + 0.25, x_r + 0.25) } else {
-      focal_x <- c(x_r - 0.25, x_r - 0.25, x_r, x_r)
-    }
-  if(lat >= y_r) {
-    focal_y <- c(y_r, y_r + 0.25, y_r, y_r + 0.25) } else {
-      focal_y <- c(y_r - 0.25, y_r, y_r - 0.25, y_r)
-    }
+  if (long >= x_r) {
+    focal_x <- c(x_r, x_r, x_r + 0.25, x_r + 0.25)
+  } else {
+    focal_x <- c(x_r - 0.25, x_r - 0.25, x_r, x_r)
+  }
+  if (lat >= y_r) {
+    focal_y <- c(y_r, y_r + 0.25, y_r, y_r + 0.25)
+  } else {
+    focal_y <- c(y_r - 0.25, y_r, y_r - 0.25, y_r)
+  }
   # work out weighting based on dist between input & 4 surrounding points
   x_dist <- abs(long - focal_x)
   y_dist <- abs(lat - focal_y)
   xy_dist <- sqrt(x_dist^2 + y_dist^2)
 
   focal <- data.frame(x = focal_x, y = focal_y, xy_dist) %>%
-    dplyr::mutate(., inverse_weight = 1/sum(1/(1/sum(xy_dist) * xy_dist)) * 1/(1/sum(xy_dist) * xy_dist))
+    dplyr::mutate(., inverse_weight = 1 / sum(1 / (1 / sum(xy_dist) * xy_dist)) * 1 / (1 / sum(xy_dist) * xy_dist))
   return(focal)
 }
 
@@ -141,45 +152,60 @@ focal_dist <- function(long, lat) {
 #' @noRd
 nc_to_df <- function(nc, long, lat, start_time, end_time, dtr_cor = TRUE,
                      dtr_cor_fac = 1) {
-
   dat <- tidync::tidync(nc) %>%
-    tidync::hyper_filter(longitude = longitude == long,
-                         latitude = latitude == lat) %>%
+    tidync::hyper_filter(
+      longitude = longitude == long,
+      latitude = latitude == lat
+    ) %>%
     tidync::hyper_tibble() %>%
-    dplyr::mutate(., obs_time = lubridate::ymd_hms("1900:01:01 00:00:00") + (time * 3600),
-                  timezone = lubridate::tz(obs_time)) %>% # convert to readable times
+    dplyr::mutate(.,
+      obs_time = lubridate::ymd_hms("1900:01:01 00:00:00") + (time * 3600),
+      timezone = lubridate::tz(obs_time)
+    ) %>% # convert to readable times
     dplyr::filter(., obs_time >= start_time & obs_time < end_time + 1) %>%
     dplyr::rename(., pressure = sp) %>%
-    dplyr::mutate(., temperature = t2m - 273.15, # kelvin to celcius
-                  lsm = dplyr::case_when(
-                    lsm < 0 ~ 0,
-                    lsm >= 0 ~ lsm),
-                  temperature = dplyr::case_when(
-                    dtr_cor == TRUE ~ coastal_correct(temperature, obs_time, lsm, dtr_cor_fac),
-                    dtr_cor == FALSE ~ temperature),
-                  humidity = humfromdew(d2m - 273.15, temperature, pressure),
-                  windspeed = sqrt(u10^2 + v10^2),
-                  windspeed = windheight(windspeed, 10, 2),
-                  winddir = (atan2(u10, v10) * 180/pi + 180)%%360,
-                  cloudcover = tcc * 100,
-                  netlong = abs(msnlwrf) * 0.0036,
-                  downlong = msdwlwrf * 0.0036,
-                  uplong = netlong + downlong,
-                  emissivity = downlong/uplong, # converted to MJ m-2 hr-1
-                  jd = julday(lubridate::year(obs_time),
-                                          lubridate::month(obs_time),
-                                          lubridate::day(obs_time)),
-                  si = siflat(lubridate::hour(obs_time), lat, long, jd, merid = 0)) %>%
-    dplyr::mutate(., rad_dni = fdir * 0.000001,
-                  rad_glbl = ssrd * 0.000001,
-                  rad_glbl = rad_calc(rad_glbl, obs_time, long, lat), # fix hourly rad
-                  rad_dni = rad_calc(rad_dni, obs_time, long, lat), # fix hourly rad
-                  rad_dif = rad_glbl - rad_dni * si) %>% # converted to MJ m-2 hr-1 from J m-2 hr-1
+    dplyr::mutate(.,
+      temperature = t2m - 273.15, # kelvin to celcius
+      lsm = dplyr::case_when(
+        lsm < 0 ~ 0,
+        lsm >= 0 ~ lsm
+      ),
+      temperature = dplyr::case_when(
+        dtr_cor == TRUE ~ coastal_correct(temperature, obs_time, lsm, dtr_cor_fac),
+        dtr_cor == FALSE ~ temperature
+      ),
+      humidity = humfromdew(d2m - 273.15, temperature, pressure),
+      windspeed = sqrt(u10^2 + v10^2),
+      windspeed = windheight(windspeed, 10, 2),
+      winddir = (atan2(u10, v10) * 180 / pi + 180) %% 360,
+      cloudcover = tcc * 100,
+      netlong = abs(msnlwrf) * 0.0036,
+      downlong = msdwlwrf * 0.0036,
+      uplong = netlong + downlong,
+      emissivity = downlong / uplong, # converted to MJ m-2 hr-1
+      jd = julday(
+        lubridate::year(obs_time),
+        lubridate::month(obs_time),
+        lubridate::day(obs_time)
+      ),
+      si = siflat(lubridate::hour(obs_time), lat, long, jd, merid = 0)
+    ) %>%
+    dplyr::mutate(.,
+      rad_dni = fdir * 0.000001,
+      rad_glbl = ssrd * 0.000001,
+      rad_glbl = rad_calc(rad_glbl, obs_time, long, lat), # fix hourly rad
+      rad_dni = rad_calc(rad_dni, obs_time, long, lat), # fix hourly rad
+      rad_dif = rad_glbl - rad_dni * si
+    ) %>% # converted to MJ m-2 hr-1 from J m-2 hr-1
     dplyr::mutate(., szenith = 90 - solalt(lubridate::hour(obs_time),
-                                                       lat, long, jd, merid = 0)) %>%
-    dplyr::select(.,obs_time, temperature, humidity, pressure, windspeed,
-                  winddir, emissivity, cloudcover, netlong, uplong, downlong,
-                  rad_dni, rad_dif, szenith, timezone)
+      lat, long, jd,
+      merid = 0
+    )) %>%
+    dplyr::select(
+      ., obs_time, temperature, humidity, pressure, windspeed,
+      winddir, emissivity, cloudcover, netlong, uplong, downlong,
+      rad_dni, rad_dif, szenith, timezone
+    )
 
   return(dat)
 }
@@ -195,13 +221,16 @@ nc_to_df <- function(nc, long, lat, start_time, end_time, dtr_cor = TRUE,
 #' @return vector of daily precipitation values
 #' @noRd
 nc_to_df_precip <- function(nc, long, lat, start_time, end_time) {
-
   dat <- tidync::tidync(nc) %>%
-    tidync::hyper_filter(longitude = longitude == long,
-                         latitude = latitude == lat) %>%
+    tidync::hyper_filter(
+      longitude = longitude == long,
+      latitude = latitude == lat
+    ) %>%
     tidync::hyper_tibble() %>%
-    dplyr::mutate(., obs_time = lubridate::ymd_hms("1900:01:01 00:00:00") + (time * 3600),
-                  timezone = lubridate::tz(obs_time)) %>% # convert to readable times
+    dplyr::mutate(.,
+      obs_time = lubridate::ymd_hms("1900:01:01 00:00:00") + (time * 3600),
+      timezone = lubridate::tz(obs_time)
+    ) %>% # convert to readable times
     dplyr::filter(., obs_time >= start_time & obs_time < end_time + 1) %>%
     dplyr::rename(., precipitation = tp) %>%
     dplyr::select(., obs_time, precipitation)
@@ -216,13 +245,11 @@ nc_to_df_precip <- function(nc, long, lat, start_time, end_time) {
 #' @return data frame of unique months and years
 #' @noRd
 uni_dates <- function(start_time, end_time) {
-
-  tme <- seq(as.POSIXlt(start_time), as.POSIXlt(end_time), by = 1)
-  mon <- lubridate::month(tme)
-  yea <- lubridate::year(tme)
-  df <- data.frame(mon,yea) %>%
-    dplyr::distinct(.)
-
+  date_seq <- seq(lubridate::floor_date(as.Date(start_time), "month"), lubridate::ceiling_date(as.Date(end_time), "month") - lubridate::days(1), by = "month")
+  df <- data.frame(
+    mon = month(date_seq),
+    yea = year(date_seq)
+  )
   return(df)
 }
 
@@ -243,7 +270,6 @@ combine_netcdf <- function(filenames, combined_name) {
   data_list <- vector(mode = "list", length = nc$nvars)
   # One variable at a time
   for (i in 1:length(names(nc$var))) {
-
     varname <- names(nc$var)[i]
     # Get the variable from each of the netCDFs
     vars_dat <- lapply(files, function(x) {
@@ -251,8 +277,10 @@ combine_netcdf <- function(filenames, combined_name) {
     })
 
     # Then bind all of the arrays together using abind, flexibly called via do.call
-    data_list[[i]] <- do.call(abind::abind, list(... = vars_dat,
-                                          along = 3))
+    data_list[[i]] <- do.call(abind::abind, list(
+      ... = vars_dat,
+      along = 3
+    ))
 
     # To populate the time dimension, need to pull out the time values from each
     # netCDF
@@ -263,20 +291,27 @@ combine_netcdf <- function(filenames, combined_name) {
     # Create a netCDF variable
     vars_list[[i]] <- ncdf4::ncvar_def(
       name = varname,
-      units =  nc$var[varname][[varname]]$units,
+      units = nc$var[varname][[varname]]$units,
       # Pull dimension names, units, and values from file1
       dim = list(
         # Longitude
-        ncdf4::ncdim_def(nc$dim$longitude$name, nc$dim$longitude$units,
-                  nc$dim$longitude$vals),
+        ncdf4::ncdim_def(
+          nc$dim$longitude$name, nc$dim$longitude$units,
+          nc$dim$longitude$vals
+        ),
         # Latitude
-        ncdf4::ncdim_def(nc$dim$latitude$name, nc$dim$latitude$units,
-                  nc$dim$latitude$vals),
+        ncdf4::ncdim_def(
+          nc$dim$latitude$name, nc$dim$latitude$units,
+          nc$dim$latitude$vals
+        ),
         # Time
-        ncdf4::ncdim_def(nc$dim$time$name, nc$dim$time$units,
-                  # Combination of values of all files
-                  do.call(c, timevals))
-      ))
+        ncdf4::ncdim_def(
+          nc$dim$time$name, nc$dim$time$units,
+          # Combination of values of all files
+          do.call(c, timevals)
+        )
+      )
+    )
   }
 
   # Create a new file
@@ -284,7 +319,8 @@ combine_netcdf <- function(filenames, combined_name) {
     # Filename from param combined_name
     filename = combined_name,
     # We need to define the variables here
-    vars = vars_list)
+    vars = vars_list
+  )
 
 
   # And write to it (must write one variable at a time with ncdf4)
@@ -292,7 +328,8 @@ combine_netcdf <- function(filenames, combined_name) {
     ncdf4::ncvar_put(
       nc = file_combined,
       varid = names(nc$var)[i],
-      vals = data_list[[i]])
+      vals = data_list[[i]]
+    )
   }
 
   # Finally, close the file


### PR DESCRIPTION
Recently the Climate Data Store (CDS) introduced a more restrictive cap on the size of data requests. As a consequence, all ERA5-data requests submitted through `build_era5_request` and `request_era5` get rejected.

This commit changes `build_era5_request` as to requests data packages at monthly intervals, thus remaining below the new CDF file size limit. The output file now follows the pattern `<outfile_name>_<year>_<month>.nc` as opposed to  `<outfile_name>_<year>.nc`.

Furthermore there is an efficiency improvement for the internal function `uni_dates`.