### PR TITLE
Modular handling of ERA5 queries from both old and new Climate Data Store (CDS) queries, modular output based on microclimate use

### DIFF
--- a/R/extract_clim.R
+++ b/R/extract_clim.R
@@ -56,7 +56,7 @@
 #'
 
 extract_clim <- function(nc, long, lat, start_time, end_time, d_weight = TRUE,
-                         dtr_cor = TRUE, dtr_cor_fac = 1.285, reformat = NULL) {
+                         dtr_cor = TRUE, dtr_cor_fac = 1.285, reformat = FALSE) {
 
   # Open nc file for error trapping
   nc_dat = ncdf4::nc_open(nc)
@@ -74,13 +74,13 @@ extract_clim <- function(nc, long, lat, start_time, end_time, d_weight = TRUE,
   }
 
   # Check if start_time is after first time observation
-  start <- lubridate::ymd_hms("1900:01:01 00:00:00") + (nc_dat$dim$time$vals[1] * 3600)
+  start <- lubridate::ymd_hms("1970:01:01 00:00:00") + (nc_dat$dim$valid_time$vals[1])
   if (start_time < start) {
     stop("Requested start time is before the beginning of time series of the ERA5 netCDF.")
   }
 
   # Check if end_time is before last time observation
-  end <- lubridate::ymd_hms("1900:01:01 00:00:00") + (utils::tail(nc_dat$dim$time$vals, n = 1) * 3600)
+  end <- lubridate::ymd_hms("1970:01:01 00:00:00") + (utils::tail(nc_dat$dim$valid_time$vals, n = 1))
   if (end_time > end) {
     stop("Requested end time is after the end of time series of the ERA5 netCDF.")
   }

--- a/R/extract_clim.R
+++ b/R/extract_clim.R
@@ -34,6 +34,10 @@
 #' @param format specifies what microclimate package extracted climate data will
 #" be used for. Data will be formatted accordingly. Default is "microclima".
 #" Options: "microclima", "NicheMapR", "microclimc", "microclimf", "micropoint"
+#' @param cds_version specifies what version of the CDS (Climate Data Store) the
+#' ERA5 data were queried from. Either "new" (queries made after Sept 2024) or
+#' "legacy" (queries made before Sept 2024). This argument will be deprecated in
+#' the future and only queries from the new CDS will be supported.
 #'
 #' @return Returns a data frame containing hourly values for a suite of climate
 #' variables. The returned climate variables depends on the value of argument `format`.
@@ -87,12 +91,24 @@
 #'
 
 extract_clim <- function(nc, long, lat, start_time, end_time, d_weight = TRUE,
-                         dtr_cor = TRUE, dtr_cor_fac = 1.285, format = "microclima") {
+                         dtr_cor = TRUE, dtr_cor_fac = 1.285, format = "microclima",
+                         cds_version = "new") {
 
   # Open nc file for error trapping
   nc_dat = ncdf4::nc_open(nc)
 
   ## Error trapping --------------
+
+  if (!cds_version %in% c("legacy", "new")) {
+    stop("Argument `cds_version` must be one of the following values: `new` or`legacy`")
+  }
+
+  # Specify the base date-time, which differs between the CDS versions
+  if (cds_version == "legacy") {
+    base_datetime <- lubridate::ymd_hms("1900:01:01 00:00:00")
+  } else {
+    base_datetime <- lubridate::ymd_hms("1970:01:01 00:00:00")
+  }
 
   # Confirm that start_time and end_time are date-time objects
   if (any(!class(start_time) %in% c("Date", "POSIXct", "POSIXt", "POSIXlt")) |
@@ -105,13 +121,13 @@ extract_clim <- function(nc, long, lat, start_time, end_time, d_weight = TRUE,
   }
 
   # Check if start_time is after first time observation
-  start <- lubridate::ymd_hms("1970:01:01 00:00:00") + (nc_dat$dim$valid_time$vals[1])
+  start <- base_datetime + (nc_dat$dim$valid_time$vals[1])
   if (start_time < start) {
     stop("Requested start time is before the beginning of time series of the ERA5 netCDF.")
   }
 
   # Check if end_time is before last time observation
-  end <- lubridate::ymd_hms("1970:01:01 00:00:00") + (utils::tail(nc_dat$dim$valid_time$vals, n = 1))
+  end <- base_datetime + (utils::tail(nc_dat$dim$valid_time$vals, n = 1))
   if (end_time > end) {
     stop("Requested end time is after the end of time series of the ERA5 netCDF.")
   }

--- a/R/extract_clima.R
+++ b/R/extract_clima.R
@@ -80,13 +80,13 @@ extract_clima <- function(
   }
 
   # Check if start_time is after first time observation
-  start <- lubridate::ymd_hms("1900:01:01 00:00:00") + (nc_dat$dim$time$vals[1] * 3600)
+  start <- lubridate::ymd_hms("1970:01:01 00:00:00") + (nc_dat$dim$valid_time$vals[1])
   if (start_time < start) {
     stop("Requested start time is before the beginning of time series of the ERA5 netCDF.")
   }
 
   # Check if end_time is before last time observation
-  end <- lubridate::ymd_hms("1900:01:01 00:00:00") + (utils::tail(nc_dat$dim$time$vals, n = 1) * 3600)
+  end <- lubridate::ymd_hms("1970:01:01 00:00:00") + (utils::tail(nc_dat$dim$valid_time$vals, n = 1))
   if (end_time > end) {
     stop("Requested end time is after the end of time series of the ERA5 netCDF.")
   }

--- a/R/extract_clima.R
+++ b/R/extract_clima.R
@@ -28,7 +28,7 @@
 #' correction. Default = 1.285, based on calibration against UK Met Office
 #' observations.
 #' @param format specifies what microclimate package extracted climate data will
-#' be used for. Data will be formatted accordingly. Default is "microclima".
+#' be used for. Data will be formatted accordingly. Default is "microclimf".
 #' Options: "microclima", "NicheMapR", "microclimc", "microclimf", "micropoint".
 #' Note: of these options, only "microclimf" accepts as input an array of climate
 #' variables. For all other models you will need to iterate through each spatial

--- a/R/extract_clima.R
+++ b/R/extract_clima.R
@@ -27,22 +27,18 @@
 #' @param dtr_cor_fac numeric value to be used in the diurnal temperature range
 #' correction. Default = 1.285, based on calibration against UK Met Office
 #' observations.
-#' @param reformat a logical indicating whether to reformat the climate variables
-#' to be suitable for modeling with microclimf. Default to reformat = `microclimf`
+#' @param format specifies what microclimate package extracted climate data will
+#' be used for. Data will be formatted accordingly. Default is "microclima".
+#' Options: "microclima", "NicheMapR", "microclimc", "microclimf", "micropoint".
+#' Note: of these options, only "microclimf" accepts as input an array of climate
+#' variables. For all other models you will need to iterate through each spatial
+#' point to run the model
 #'
-#' @return a list of wrapped spatRasters containing hourly values for a suite of climate variables. The returned climate variables depends on whether the parameter `reformat` is `microclimf`.
-#' If `reformat` == "microclimf":
-#' @return `temp` | (degrees celsius)
-#' @return `relhum` | relative humidity (ercentage)
-#' @return `pres` | atmospheric press (kPa)
-#' @return `swdown` | Flux density of total downward shortwave radiation on the horizontal (W / m^2)
-#' @return `difrad` | Diffuse radiation (W / m^2)
-#' @return `lwdown` | Flux density of total downward downward radiation (W / m^2)
-#' @return `windspeed` | (m / s)
-#' @return `winddir` | wind direction, azimuth (decimal degrees from north)
-#' @return `precip` | precipitation (mm)
+#' @return Returns a list of wrapped spatRasters containing hourly values for a
+#' suite of climate variables. The returned climate variables depends on the
+#' value of argument `format`.
 #'
-#' If `reformat` is NULL or some other value:
+#' If format is "microclima" or "NicheMapR":
 #' @return `obs_time` | the date-time (timezone specified in col timezone)
 #' @return `temperature` | (degrees celsius)
 #' @return `humidity` | specific humidity (kg / kg)
@@ -58,12 +54,39 @@
 #' @return `rad_dni` | Direct normal irradiance (MJ / m2 / hr)
 #' @return `rad_dif` | Diffuse normal irradiance (MJ / m2 / hr)
 #' @return `szenith` | Solar zenith angle (degrees from a horizontal plane)
+#' @return `timezone` | (unitless)
+#'
+#' If format is "microclimc":
+#' @return `obs_time` | POSIXlt object of dates and times
+#' @return `temp` | temperature (degrees C)
+#' @return `relhum` | relative humidity (percentage)
+#' @return `pres` | atmospheric press (kPa)
+#' @return `swrad` | Total incoming shortwave radiation (W / m^2)
+#' @return `difrad` | Diffuse radiation (W / m^2)
+#' @return `skyem` | Sky emissivity (0-1)
+#' @return `lwdown` | Total downward longwave radiation (W / m^2)
+#' @return `windspeed` | Wind speed (m/s)
+#' @return `winddir` | Wind direction (decimal degrees)
+#' @return `precip` | precipitation (mm)
+#'
+#' If format is "micropoint" or "microclimf":
+#' @return `obs_time` | POSIXlt object of dates and times
+#' @return `temp` | temperature (degrees C)
+#' @return `relhum` | relative humidity (percentage)
+#' @return `pres` | atmospheric press (kPa)
+#' @return `swdown` | Total incoming shortwave radiation (W / m^2)
+#' @return `difrad` | Diffuse radiation (W / m^2)
+#' @return `skyem` | Sky emissivity (0-1)
+#' @return `lwdown` | Total downward longwave radiation (W / m^2)
+#' @return `windspeed` | Wind speed (m/s)
+#' @return `winddir` | Wind direction (decimal degrees)
+#' @return `precip` | precipitation (mm)
 #'
 #' @export
 extract_clima <- function(
     nc, long_min, long_max, lat_min, lat_max, start_time, end_time,
     dtr_cor = TRUE, dtr_cor_fac = 1.285,
-    reformat = "microclimf") {
+    format = "microclimf") {
   # Open nc file for error trapping
   nc_dat = ncdf4::nc_open(nc)
 
@@ -140,16 +163,21 @@ extract_clima <- function(
     warning("provided times (start_time and end_time) are not in timezone UTC (default timezone of ERA5 data). Output will be provided in timezone UTC however.")
   }
 
-  if (dtr_cor == TRUE & !is.numeric(dtr_cor_fac)) {
-    stop("Invalid diurnal temperature range correction value provided.")
-  }
-
   # Specify hour of end_time as last hour of day, if not specified
   if (lubridate::hour(end_time) == 0) {
     end_time <- as.POSIXlt(paste0(lubridate::year(end_time), "-",
                                   lubridate::month(end_time), "-",
                                   lubridate::day(end_time),
                                   " 23:00"), tz = lubridate::tz(end_time))
+  }
+
+  # Check that `format` is an accepted value
+  if (!format %in% c("NicheMapR", "microclima", "microclimc", "micropoint", "microclimf")) {
+    stop("Argument `format` must be one of the following values: `NicheMapR`, `microclima`, `microclimc`, `micropoint`, `microclimf`")
+  }
+
+  if (dtr_cor == TRUE & !is.numeric(dtr_cor_fac)) {
+    stop("Invalid diurnal temperature range correction value provided.")
   }
 
   tme <- as.POSIXct(seq(start_time,
@@ -190,7 +218,7 @@ extract_clima <- function(
   msdwlwrf <- var_list$msdwlwrf
   fdir <- var_list$fdir
   ssrd <- var_list$ssrd
-  prec <- var_list$tp * 1000 # convert form mm to metres
+  prec <- var_list$tp * 1000 # convert from mm to metres
   lsm <- var_list$lsm
   temperature <- t2m - 273.15 # kelvin to celcius
   ## Coastal correction ----------
@@ -223,15 +251,15 @@ extract_clima <- function(
   windspeed = windheight(windspeed, 10, 2)
   winddir = (terra::atan2(u10, v10) * 180/pi + 180)%%360
   cloudcover = tcc * 100
-  netlong = abs(msnlwrf) * 0.0036
-  downlong = msdwlwrf * 0.0036
+  netlong = abs(msnlwrf) * 0.0036 # Convert to MJ/m^2/hr
+  downlong = msdwlwrf * 0.0036 # Convert to MJ/m^2/hr
   uplong = netlong + downlong
-  emissivity = downlong/uplong # converted to MJ m-2 hr-1
+  emissivity = downlong/uplong
   jd = julday(lubridate::year(tme),
               lubridate::month(tme),
               lubridate::day(tme))
-  rad_dni = fdir * 0.000001
-  rad_glbl = ssrd * 0.000001
+  rad_dni = fdir * 0.000001 # Convert form J/m^2 to MJ/m^2
+  rad_glbl = ssrd * 0.000001 # Convert form J/m^2 to MJ/m^2
   ## si processing -----------------
   # use t2m as template of dimensions for iterating through
   si <- t2m
@@ -253,7 +281,7 @@ extract_clima <- function(
   si <- terra::setValues(si, out)
 
   # Calc rad_dif
-  rad_dif = rad_glbl - rad_dni * si # converted to MJ m-2 hr-1 from J m-2 hr-1
+  rad_dif = rad_glbl - rad_dni * si
   ## szenith processing -----------------
   # use t2m as template of dimensions for iterating through
   szenith <- t2m
@@ -272,9 +300,9 @@ extract_clima <- function(
   names(temperature) <- names(t2m)
   terra::time(temperature) <- terra::time(t2m)
 
-  ## Reformat ----------
+  ## Format of output use ----------
   ## Equivalent of hourlyncep_convert
-  if (reformat == "microclimf") {
+  if (format %in% c("microclimc", "micropoint", "microclimf")) {
     pres <- sp / 1000
     ## Convert humidity from specific to relative
     relhum <- humidity
@@ -283,12 +311,13 @@ extract_clima <- function(
                                              tc  = terra::as.array(temperature),
                                              pk = terra::as.array(pres))$relative
     relhum[relhum > 100] <- 100
-    raddr <- (rad_dni * si)/0.0036
-    difrad <- rad_dif/0.0036
+    raddr <- (rad_dni * si)/0.0036 # convert back to W/m^2
+    difrad <- rad_dif/0.0036 # convert from MJ/hr to W/m^2
     swrad <- raddr + difrad
+    downlong <- downlong / 0.0036 # convert from MJ/hr to W/m^2
   }
-  # Return list - ## SpatRasters now wrapped as won't store as list if saved otherwise'
-  if (reformat == "microclimf") {
+  # Return list - SpatRasters now wrapped as won't store as list if saved otherwise'
+  if (format %in% c("microclimc", "micropoint", "microclimf")) {
     return(list(temp = terra::wrap(temperature),
                 relhum = terra::wrap(relhum),
                 pres = terra::wrap(pres),
@@ -315,4 +344,3 @@ extract_clima <- function(
                 szenith = terra::wrap(szenith)))
   }
 }
-

--- a/R/extract_land_clim.R
+++ b/R/extract_land_clim.R
@@ -53,13 +53,13 @@ extract_land_clim <- function(nc, long, lat, start_time, end_time, d_weight = TR
   }
 
   # Check if start_time is after first time observation
-  start <- lubridate::ymd_hms("1900:01:01 00:00:00") + (nc_dat$dim$time$vals[1] * 3600)
+  start <- lubridate::ymd_hms("1970:01:01 00:00:00") + (nc_dat$dim$valid_time$vals[1])
   if (start_time < start) {
     stop("Requested start time is before the beginning of time series of the ERA5 netCDF.")
   }
 
   # Check if end_time is before last time observation
-  end <- lubridate::ymd_hms("1900:01:01 00:00:00") + (utils::tail(nc_dat$dim$time$vals, n = 1) * 3600)
+  end <- lubridate::ymd_hms("1970:01:01 00:00:00") + (utils::tail(nc_dat$dim$valid_time$vals, n = 1))
   if (end_time > end) {
     stop("Requested end time is after the end of time series of the ERA5 netCDF.")
   }

--- a/R/extract_land_clim.R
+++ b/R/extract_land_clim.R
@@ -21,6 +21,10 @@
 #' @param d_weight logical value indicating whether to apply inverse distance
 #' weighting using the 4 closest neighbouring points to the location defined by
 #' `long` and `lat`. Default = `TRUE`.
+#' @param cds_version specifies what version of the CDS (Climate Data Store) the
+#' ERA5 data were queried from. Either "new" (queries made after Sept 2024) or
+#' "legacy" (queries made before Sept 2024). This argument will be deprecated in
+#' the future and only queries from the new CDS will be supported.
 #'
 #' @return a data frame containing hourly values for a suite of climate variables:
 #' @return `obs_time` | the date-time (timezone specified in col timezone)
@@ -36,11 +40,23 @@
 #'
 #'
 
-extract_land_clim <- function(nc, long, lat, start_time, end_time, d_weight = TRUE) {
+extract_land_clim <- function(nc, long, lat, start_time, end_time, d_weight = TRUE,
+                              cds_version = "new") {
   # Open nc file for error trapping
   nc_dat <- ncdf4::nc_open(nc)
 
-  ## Error trapping
+  ## Error trapping ---------------
+
+  if (!cds_version %in% c("legacy", "new")) {
+    stop("Argument `cds_version` must be one of the following values: `new` or`legacy`")
+  }
+
+  # Specify the base date-time, which differs between the CDS versions
+  if (cds_version == "legacy") {
+    base_datetime <- lubridate::ymd_hms("1900:01:01 00:00:00")
+  } else {
+    base_datetime <- lubridate::ymd_hms("1970:01:01 00:00:00")
+  }
 
   # Confirm that start_time and end_time are date-time objects
   if (any(!class(start_time) %in% c("Date", "POSIXct", "POSIXt", "POSIXlt")) |

--- a/R/extract_precip.R
+++ b/R/extract_precip.R
@@ -50,13 +50,13 @@ extract_precip <- function(nc, long, lat, start_time, end_time,
   }
 
   # Check if start_time is after first time observation
-  start <- lubridate::ymd_hms("1900:01:01 00:00:00") + (nc_dat$dim$time$vals[1] * 3600)
+  start <- lubridate::ymd_hms("1970:01:01 00:00:00") + (nc_dat$dim$valid_time$vals[1])
   if (start_time < start) {
     stop("Requested start time is before the beginning of time series of the ERA5 netCDF.")
   }
 
   # Check if end_time is before last time observation
-  end <- lubridate::ymd_hms("1900:01:01 00:00:00") + (utils::tail(nc_dat$dim$time$vals, n = 1) * 3600)
+  end <- lubridate::ymd_hms("1970:01:01 00:00:00") + (utils::tail(nc_dat$dim$valid_time$vals, n = 1))
   if (end_time > end) {
     stop("Requested end time is after the end of time series of the ERA5 netCDF.")
   }

--- a/R/extract_precip.R
+++ b/R/extract_precip.R
@@ -26,18 +26,33 @@
 #' @param convert_daily a flag indicating whether the user desires to convert the
 #' precipitation vector from hourly to daily averages (TRUE) or remain as hourly
 #' values (FALSE). Only daily precipitation will be accepted by `microclima::runauto`.
+#' @param cds_version specifies what version of the CDS (Climate Data Store) the
+#' ERA5 data were queried from. Either "new" (queries made after Sept 2024) or
+#' "legacy" (queries made before Sept 2024). This argument will be deprecated in
+#' the future and only queries from the new CDS will be supported.
 #'
 #' @return a numeric vector of daily or hourly precipitation (mm).
 #' @export
 #'
 #'
 extract_precip <- function(nc, long, lat, start_time, end_time,
-                                  d_weight = TRUE, convert_daily = TRUE) {
+                                  d_weight = TRUE, convert_daily = TRUE,
+                           cds_version = "new") {
 
   # Open nc file for error trapping
   nc_dat = ncdf4::nc_open(nc)
 
-  ## Error trapping
+  ## Error trapping --------------
+  if (!cds_version %in% c("legacy", "new")) {
+    stop("Argument `cds_version` must be one of the following values: `new` or`legacy`")
+  }
+
+  # Specify the base date-time, which differs between the CDS versions
+  if (cds_version == "legacy") {
+    base_datetime <- lubridate::ymd_hms("1900:01:01 00:00:00")
+  } else {
+    base_datetime <- lubridate::ymd_hms("1970:01:01 00:00:00")
+  }
 
   # Confirm that start_time and end_time are date-time objects
   if (any(!class(start_time) %in% c("Date", "POSIXct", "POSIXt", "POSIXlt")) |
@@ -50,13 +65,13 @@ extract_precip <- function(nc, long, lat, start_time, end_time,
   }
 
   # Check if start_time is after first time observation
-  start <- lubridate::ymd_hms("1970:01:01 00:00:00") + (nc_dat$dim$valid_time$vals[1])
+  start <- base_datetime + (nc_dat$dim$valid_time$vals[1])
   if (start_time < start) {
     stop("Requested start time is before the beginning of time series of the ERA5 netCDF.")
   }
 
   # Check if end_time is before last time observation
-  end <- lubridate::ymd_hms("1970:01:01 00:00:00") + (utils::tail(nc_dat$dim$valid_time$vals, n = 1))
+  end <- base_datetime + (utils::tail(nc_dat$dim$valid_time$vals, n = 1))
   if (end_time > end) {
     stop("Requested end time is after the end of time series of the ERA5 netCDF.")
   }

--- a/R/extract_precipa.R
+++ b/R/extract_precipa.R
@@ -24,18 +24,35 @@
 #' @param convert_daily a flag indicating whether the user desires to convert the
 #'  precipitation spatRaster from hourly to daily averages (TRUE) or remain as hourly
 #' values (FALSE). Only daily precipitation will be accepted by `microclimf::modelina`.
+#' @param cds_version specifies what version of the CDS (Climate Data Store) the
+#' ERA5 data were queried from. Either "new" (queries made after Sept 2024) or
+#' "legacy" (queries made before Sept 2024). This argument will be deprecated in
+#' the future and only queries from the new CDS will be supported.
 #'
 #' @return a spatRaster of daily or hourly precipitation (mm).
 #' @export
 #'
 #'
 extract_precipa <- function(nc, long_min, long_max, lat_min, lat_max,
-                            start_time, end_time, convert_daily = TRUE) {
+                            start_time, end_time, convert_daily = TRUE,
+                            cds_version = "new") {
 
   # Open nc file for error trapping
   nc_dat = ncdf4::nc_open(nc)
 
-  ## Error trapping
+  ## Error trapping ------------------
+
+  if (!cds_version %in% c("legacy", "new")) {
+    stop("Argument `cds_version` must be one of the following values: `new` or`legacy`")
+  }
+
+  # Specify the base date-time, which differs between the CDS versions
+  if (cds_version == "legacy") {
+    base_datetime <- lubridate::ymd_hms("1900:01:01 00:00:00")
+  } else {
+    base_datetime <- lubridate::ymd_hms("1970:01:01 00:00:00")
+  }
+
 
   # Confirm that start_time and end_time are date-time objects
   if (any(!class(start_time) %in% c("Date", "POSIXct", "POSIXt", "POSIXlt")) |

--- a/R/extract_precipa.R
+++ b/R/extract_precipa.R
@@ -48,13 +48,13 @@ extract_precipa <- function(nc, long_min, long_max, lat_min, lat_max,
   }
 
   # Check if start_time is after first time observation
-  start <- lubridate::ymd_hms("1900:01:01 00:00:00") + (nc_dat$dim$time$vals[1] * 3600)
+  start <- lubridate::ymd_hms("1970:01:01 00:00:00") + (nc_dat$dim$valid_time$vals[1])
   if (start_time < start) {
     stop("Requested start time is before the beginning of time series of the ERA5 netCDF.")
   }
 
   # Check if end_time is before last time observation
-  end <- lubridate::ymd_hms("1900:01:01 00:00:00") + (utils::tail(nc_dat$dim$time$vals, n = 1) * 3600)
+  end <- lubridate::ymd_hms("1970:01:01 00:00:00") + (utils::tail(nc_dat$dim$valid_time$vals, n = 1))
   if (end_time > end) {
     stop("Requested end time is after the end of time series of the ERA5 netCDF.")
   }

--- a/R/internal.R
+++ b/R/internal.R
@@ -161,7 +161,7 @@ nc_to_df <- function(nc, long, lat, start_time, end_time, dtr_cor = TRUE,
     ) %>%
     tidync::hyper_tibble() %>%
     dplyr::mutate(.,
-      obs_time = lubridate::ymd_hms("1970:01:01 00:00:00") + ncdf4::nc_open(nc)$dim$valid_time$vals,
+      obs_time = lubridate::ymd_hms("1970:01:01 00:00:00") + c(ncdf4::nc_open(nc)$dim$valid_time$vals),
       timezone = lubridate::tz(obs_time)
     ) %>% # convert to readable times
     dplyr::filter(., obs_time >= start_time & obs_time < end_time + 1) %>%

--- a/R/internal.R
+++ b/R/internal.R
@@ -160,7 +160,7 @@ nc_to_df <- function(nc, long, lat, start_time, end_time, dtr_cor = TRUE,
     ) %>%
     tidync::hyper_tibble() %>%
     dplyr::mutate(.,
-      obs_time = lubridate::ymd_hms("1900:01:01 00:00:00") + (time * 3600),
+      obs_time = lubridate::ymd_hms("1970:01:01 00:00:00") + nc_dat$dim$valid_time$vals,
       timezone = lubridate::tz(obs_time)
     ) %>% # convert to readable times
     dplyr::filter(., obs_time >= start_time & obs_time < end_time + 1) %>%

--- a/R/internal.R
+++ b/R/internal.R
@@ -153,6 +153,7 @@ focal_dist <- function(long, lat, margin = .25) {
 #' @noRd
 nc_to_df <- function(nc, long, lat, start_time, end_time, dtr_cor = TRUE,
                      dtr_cor_fac = 1, reformat = NULL) {
+
   dat <- tidync::tidync(nc) %>%
     tidync::hyper_filter(
       longitude = longitude == long,
@@ -160,7 +161,7 @@ nc_to_df <- function(nc, long, lat, start_time, end_time, dtr_cor = TRUE,
     ) %>%
     tidync::hyper_tibble() %>%
     dplyr::mutate(.,
-      obs_time = lubridate::ymd_hms("1970:01:01 00:00:00") + nc_dat$dim$valid_time$vals,
+      obs_time = lubridate::ymd_hms("1970:01:01 00:00:00") + ncdf4::nc_open(nc)$dim$valid_time$vals,
       timezone = lubridate::tz(obs_time)
     ) %>% # convert to readable times
     dplyr::filter(., obs_time >= start_time & obs_time < end_time + 1) %>%

--- a/R/internal.R
+++ b/R/internal.R
@@ -152,7 +152,16 @@ focal_dist <- function(long, lat, margin = .25) {
 #' @return data frame of hourly climate variables
 #' @noRd
 nc_to_df <- function(nc, long, lat, start_time, end_time, dtr_cor = TRUE,
-                     dtr_cor_fac = 1, format = "microclima") {
+                     dtr_cor_fac = 1, format = "microclima", cds_version = "new") {
+
+  if (cds_version == "legacy") {
+    base_datetime <- lubridate::ymd_hms("1900:01:01 00:00:00")
+    nc_datetimes <- c(ncdf4::nc_open(nc)$dim$time$vals) * 3600
+  } else {
+    base_datetime <- lubridate::ymd_hms("1970:01:01 00:00:00")
+    nc_datetimes <- c(ncdf4::nc_open(nc)$dim$valid_time$vals)
+  }
+
   dat <- tidync::tidync(nc) %>%
     tidync::hyper_filter(
       longitude = longitude == long,
@@ -160,7 +169,7 @@ nc_to_df <- function(nc, long, lat, start_time, end_time, dtr_cor = TRUE,
     ) %>%
     tidync::hyper_tibble() %>%
     dplyr::mutate(.,
-      obs_time = lubridate::ymd_hms("1970:01:01 00:00:00") + c(ncdf4::nc_open(nc)$dim$valid_time$vals),
+      obs_time = base_datetime + nc_datetimes,
       timezone = lubridate::tz(obs_time)
     ) %>% # convert to readable times
     dplyr::filter(., obs_time >= start_time & obs_time < end_time + 1) %>%
@@ -261,7 +270,16 @@ nc_to_df <- function(nc, long, lat, start_time, end_time, dtr_cor = TRUE,
 #' @param end_time end time for data required
 #' @return data frame of hourly climate variables
 #' @noRd
-nc_to_df_land <- function(nc, long, lat, start_time, end_time) {
+nc_to_df_land <- function(nc, long, lat, start_time, end_time, cds_version = "new") {
+
+  if (cds_version == "legacy") {
+    base_datetime <- lubridate::ymd_hms("1900:01:01 00:00:00")
+    nc_datetimes <- c(ncdf4::nc_open(nc)$dim$time$vals) * 3600
+  } else {
+    base_datetime <- lubridate::ymd_hms("1970:01:01 00:00:00")
+    nc_datetimes <- c(ncdf4::nc_open(nc)$dim$valid_time$vals)
+  }
+
   dat <- tidync::tidync(nc) %>%
     tidync::hyper_filter(
       # ERA5-Land does not return precise coordinate values
@@ -270,7 +288,7 @@ nc_to_df_land <- function(nc, long, lat, start_time, end_time) {
     ) %>%
     tidync::hyper_tibble() %>%
     dplyr::mutate(.,
-      obs_time = lubridate::ymd_hms("1970:01:01 00:00:00") + c(ncdf4::nc_open(nc)$dim$valid_time$vals),
+      obs_time = base_datetime + nc_datetimes,
       timezone = lubridate::tz(obs_time)
     ) %>% # convert to readable times
     dplyr::filter(., obs_time >= start_time & obs_time < end_time + 1) %>%
@@ -310,7 +328,16 @@ nc_to_df_land <- function(nc, long, lat, start_time, end_time) {
 #' @param end_time end time for data required
 #' @return vector of daily precipitation values
 #' @noRd
-nc_to_df_precip <- function(nc, long, lat, start_time, end_time) {
+nc_to_df_precip <- function(nc, long, lat, start_time, end_time, cds_version = "new") {
+
+  if (cds_version == "legacy") {
+    base_datetime <- lubridate::ymd_hms("1900:01:01 00:00:00")
+    nc_datetimes <- c(ncdf4::nc_open(nc)$dim$time$vals) * 3600
+  } else {
+    base_datetime <- lubridate::ymd_hms("1970:01:01 00:00:00")
+    nc_datetimes <- c(ncdf4::nc_open(nc)$dim$valid_time$vals)
+  }
+
   dat <- tidync::tidync(nc) %>%
     tidync::hyper_filter(
       longitude = longitude == long,
@@ -318,7 +345,7 @@ nc_to_df_precip <- function(nc, long, lat, start_time, end_time) {
     ) %>%
     tidync::hyper_tibble() %>%
     dplyr::mutate(.,
-      obs_time = lubridate::ymd_hms("1970:01:01 00:00:00") + c(ncdf4::nc_open(nc)$dim$valid_time$vals),
+      obs_time = base_datetime + nc_datetimes,
       timezone = lubridate::tz(obs_time)
     ) %>% # convert to readable times
     dplyr::filter(., obs_time >= start_time & obs_time < end_time + 1) %>%

--- a/R/internal.R
+++ b/R/internal.R
@@ -249,7 +249,7 @@ nc_to_df_land <- function(nc, long, lat, start_time, end_time) {
     ) %>%
     tidync::hyper_tibble() %>%
     dplyr::mutate(.,
-      obs_time = lubridate::ymd_hms("1900:01:01 00:00:00") + (time * 3600),
+      obs_time = lubridate::ymd_hms("1970:01:01 00:00:00") + c(ncdf4::nc_open(nc)$dim$valid_time$vals),,
       timezone = lubridate::tz(obs_time)
     ) %>% # convert to readable times
     dplyr::filter(., obs_time >= start_time & obs_time < end_time + 1) %>%
@@ -297,7 +297,7 @@ nc_to_df_precip <- function(nc, long, lat, start_time, end_time) {
     ) %>%
     tidync::hyper_tibble() %>%
     dplyr::mutate(.,
-      obs_time = lubridate::ymd_hms("1900:01:01 00:00:00") + (time * 3600),
+      obs_time = lubridate::ymd_hms("1970:01:01 00:00:00") + c(ncdf4::nc_open(nc)$dim$valid_time$vals),
       timezone = lubridate::tz(obs_time)
     ) %>% # convert to readable times
     dplyr::filter(., obs_time >= start_time & obs_time < end_time + 1) %>%

--- a/inst/doc/mcera5_vignette.R
+++ b/inst/doc/mcera5_vignette.R
@@ -1,4 +1,4 @@
-## ----setup, include=FALSE------------------------------------------------------------------------------------------------------
+## ----setup, include=FALSE---------------------------------------------------------------------------------------
 knitr::opts_chunk$set(echo = TRUE,
                       collapse = TRUE,
                       comment = "#>")
@@ -6,7 +6,7 @@ knitr::opts_chunk$set(echo = TRUE,
 # be different from the \VignetteIndexEntry{} title:
 options(rmarkdown.html_vignette.check_title = FALSE)
 
-## ----packages, warning = FALSE, message = FALSE--------------------------------------------------------------------------------
+## ----packages, warning = FALSE, message = FALSE-----------------------------------------------------------------
 library(mcera5)
 library(dplyr)
 library(ecmwfr)
@@ -19,7 +19,7 @@ library(tidync)
 library(NicheMapR) # remotes::install_github("mrke/NicheMapR")
 library(microctools) # remotes::install_github("ilyamaclean/microctools")
 
-## ----funs, include = FALSE-----------------------------------------------------------------------------------------------------
+## ----funs, include = FALSE--------------------------------------------------------------------------------------
 #############
 ##FUNCTIONS##
 #############
@@ -27,7 +27,7 @@ library(microctools) # remotes::install_github("ilyamaclean/microctools")
 files_source <- list.files(here::here("R/"), full.names = T)
 sapply(files_source,source)
 
-## ----creds, eval = FALSE-------------------------------------------------------------------------------------------------------
+## ----creds, eval = FALSE----------------------------------------------------------------------------------------
 #  # assign your credentials from the CDS User ID and Personal Access Token
 #  uid <- "*****"
 #  cds_access_token <- "********-****-****-****-************"
@@ -36,7 +36,7 @@ sapply(files_source,source)
 #                     key = cds_access_token,
 #                     service = "cds")
 
-## ----build request-------------------------------------------------------------------------------------------------------------
+## ----build request----------------------------------------------------------------------------------------------
 
 # bounding coordinates (in WGS84 / EPSG:4326)
 xmn <- -4
@@ -62,13 +62,13 @@ req <- build_era5_request(xmin = xmn, xmax = xmx,
                           end_time = en_time,
                           outfile_name = file_prefix)
 
-## ----list_view-----------------------------------------------------------------------------------------------------------------
+## ----list_view--------------------------------------------------------------------------------------------------
 str(req)
 
-## ----send_request, eval = FALSE------------------------------------------------------------------------------------------------
+## ----send_request, eval = FALSE---------------------------------------------------------------------------------
 #  request_era5(request = req, uid = uid, out_path = file_path)
 
-## ----process_clim, eval = FALSE------------------------------------------------------------------------------------------------
+## ----process_clim, eval = FALSE---------------------------------------------------------------------------------
 #  # list the path of the .nc file for a given year
 #  my_nc <- paste0(getwd(), "/era5_-4_-2_49_51_2010.nc")
 #  
@@ -78,10 +78,12 @@ str(req)
 #  
 #  # gather all hourly variables
 #  clim_point <- extract_clim(nc = my_nc, long = x, lat = y,
-#                              start_time = st_time, end_time = en_time)
+#                            start_time = st_time, end_time = en_time,
+#                             format = "microclima")
+#  
 #  head(clim_point)
 
-## ----process_precip, eval = FALSE----------------------------------------------------------------------------------------------
+## ----process_precip, eval = FALSE-------------------------------------------------------------------------------
 #  # gather daily precipitation (we specify to convert precipitation from hourly
 #  # to daily, which is already the default behavior)
 #  precip_point <- extract_precip(nc = my_nc, long = x, lat = y,
@@ -89,7 +91,7 @@ str(req)
 #                                     end_time = en_time,
 #                                     convert_daily = TRUE)
 
-## ----runauto_example, eval = FALSE---------------------------------------------------------------------------------------------
+## ----runauto_example, eval = FALSE------------------------------------------------------------------------------
 #  # create a 200 x 200 30 m spatial resoltuion DEM for location
 #  r <- microclima::get_dem(lat = y, long = x, resolution = 30)
 #  
@@ -101,10 +103,22 @@ str(req)
 #                               dailyprecip = precip_point,
 #                               plot.progress= FALSE)
 
-## ----hourlyncep_convert_example, eval = FALSE----------------------------------------------------------------------------------
-#  climdata <- hourlyncep_convert(climdata = clim_point, lat = y, long = x)
+## ----process_clim_microclimc, eval = FALSE----------------------------------------------------------------------
+#  # list the path of the .nc file for a given year
+#  my_nc <- paste0(getwd(), "/era5_-4_-2_49_51_2010.nc")
+#  
+#  # for a single point (make sure it's within the bounds of your .nc file)
+#  x <- -3.654600
+#  y <- 50.640369
+#  
+#  # gather all hourly variables
+#  clim_point <- extract_clim(nc = my_nc, long = x, lat = y,
+#                            start_time = st_time, end_time = en_time,
+#                             format = "microclimc")
+#  
+#  head(clim_point)
 
-## ----process_clima, eval = FALSE-----------------------------------------------------------------------------------------------
+## ----process_clima, eval = FALSE--------------------------------------------------------------------------------
 #  # list the path of the .nc file for a given year
 #  my_nc <- paste0(getwd(), "/era5_-4_-2_49_51_2010.nc")
 #  
@@ -119,7 +133,7 @@ str(req)
 #                            start_time = st_time,
 #                            end_time = en_time,
 #                            dtr_cor = TRUE, dtr_cor_fac = 1.285,
-#                            reformat = TRUE)
+#                            format = "microclimf")
 #  
 #  str(clim_grid)
 #  

--- a/inst/doc/mcera5_vignette.R
+++ b/inst/doc/mcera5_vignette.R
@@ -33,8 +33,7 @@ sapply(files_source,source)
 #  cds_access_token <- "********-****-****-****-************"
 #  
 #  ecmwfr::wf_set_key(user = uid,
-#                     key = cds_access_token,
-#                     service = "cds")
+#                     key = cds_access_token)
 
 ## ----build request----------------------------------------------------------------------------------------------
 

--- a/inst/doc/mcera5_vignette.Rmd
+++ b/inst/doc/mcera5_vignette.Rmd
@@ -129,6 +129,7 @@ By default, `extract_clim` applies an inverse distance weighting calculation (co
 Furthermore, `extract_clim` by default applies a diurnal temperature range correction to the data (when `dtr_cor = TRUE` and weighted according to `dtr_cor_fac`). The diurnal temperature ranges of ERA5 are artificially lower in grid cells classed as sea as opposed to land. It may thus be useful to apply a correction if estimates are required for a terrestrial location in predominantly marine grid cells. If applied, an internal function is evoked that uses the land/sea value in the downloaded NetCDF file to adjust temperature values by the factor provided using the formula $DTR_C=DTR[(1-p_l ) C_f+1]$ where $DTR_C$ is the corrected diurnal temperature range, $DTR$ is the diurnal temperature range in the ERA5 dataset, $p_l$ is the proportion of the grid cell that is land and $C_f$ is the correction factor. The default function input value is a correction based on calibration against the UK Met Office 1-km2 gridded dataset of daily maximum and minimum temperatures, itself calibrated and validated against a network of (on average) 1,203 weather stations distributed across the UK. 
 
 Given that `runauto` in the `microclima` package, as well as functions from the `NicheMapR` and `microclimc` microclimate modelling packages, all only accept date ranges within single years, you will need to create a separate data frame for each yearly block. For example, if your period of interest spans multiple years (and you have used the previous code to download multiple .nc files, run this next block of code for each year):
+The climate data that are extracted will have different formats according to the value provided to `format`. By default, `extract_clim()` will provide data formatted for `microclima`.
 
 ```{r process_clim, eval = FALSE}
 # list the path of the .nc file for a given year
@@ -140,10 +141,11 @@ y <- 50.640369
 
 # gather all hourly variables
 clim_point <- extract_clim(nc = my_nc, long = x, lat = y,
-                            start_time = st_time, end_time = en_time)
+                          start_time = st_time, end_time = en_time,
+                           format = "microclima")
+
 head(clim_point)
 ```
-
 
 
 In the same fashion, use `extract_precip` to acquire precipitation from your downloaded netCDF file, which also applies an inverse distance weighting calculation. By default, `extract_precip` sums up hourly ERA5 precipitation to the daily level, which is required for the aforementioned microclimate models. However users can instead receive hourly values by setting `convert_daily = FALSE`. 
@@ -172,18 +174,30 @@ temps <- microclima::runauto(r = r, dstart = "26/02/2010",dfinish = "01/03/2010"
                              plot.progress= FALSE)
 ```
 
-For use of climate data with other microclimate packages, such as `microclimc` and `microclimf`, you may need to reformat the climate data using `microctools::hourlyncep_convert`:
+For use of climate data with other microclimate packages, such as `microclimc` and `microclimf`, you can specify the package name with the argument `format`:
 
-```{r hourlyncep_convert_example, eval = FALSE}
-climdata <- hourlyncep_convert(climdata = clim_point, lat = y, long = x)
+```{r process_clim_microclimc, eval = FALSE}
+# list the path of the .nc file for a given year
+my_nc <- paste0(getwd(), "/era5_-4_-2_49_51_2010.nc")
+
+# for a single point (make sure it's within the bounds of your .nc file)
+x <- -3.654600
+y <- 50.640369
+
+# gather all hourly variables
+clim_point <- extract_clim(nc = my_nc, long = x, lat = y,
+                          start_time = st_time, end_time = en_time,
+                           format = "microclimc")
+
+head(clim_point)
 ```
 
 #### Extracting climate data for a spatial grid/array using extract_clima() and extract_precipa()
 
 
-`mcera5` also can extract ERA5 climate data simultaneously across a spatial grid using `extract_clima()` and `extract_precipa()`, to be provided to functions such as `microclimf::modelina()`. `extract_clima()` and `extract_precipa()` follow the same format as `extract_clim()` and `extract_precip()`, except require as input the boundaries of a spatial grid rather than a single spatial point. Both functions will return spatRaster layers corresponding to the climate variables.
+`mcera5` also can extract ERA5 climate data simultaneously across a spatial grid using `extract_clima()` and `extract_precipa()`, to be provided to functions such as `microclimf::runpointmodela()`. `extract_clima()` and `extract_precipa()` follow the same format as `extract_clim()` and `extract_precip()`, except require as input the boundaries of a spatial grid rather than a single spatial point. Both functions will return spatRaster layers corresponding to the climate variables, formatted according to what package is specified in the argument `format`.
 
-`extract_clima` also includes the argument `reformat`, which when set to TRUE (the default value) will reformat climate data to be used for modeling with `microclimf`. Similarly, `extract_precipa` has the argument `convert_daily` to sum hourly preicipitation to daily precipitation, which is accepted by `microclimf` functions.
+The function `extract_precipa` also has the argument `convert_daily` to sum hourly preicipitation to daily precipitation, which is accepted by `microclimf` functions.
 
 ```{r process_clima, eval = FALSE}
 # list the path of the .nc file for a given year
@@ -200,7 +214,7 @@ clim_grid <- extract_clima(nc, long_min, long_max, lat_min, lat_max,
                           start_time = st_time,
                           end_time = en_time,
                           dtr_cor = TRUE, dtr_cor_fac = 1.285,
-                          reformat = TRUE)
+                          format = "microclimf")
 
 str(clim_grid)
 
@@ -215,4 +229,4 @@ str(precip_grid)
 
 #### Acknowledgements
 
-Thank you to Koen Hufkens, creator of the `ecwmfr` package for making the aquisition of ECWMF data through R possible. 
+Thank you to Koen Hufkens, creator of the `ecwmfr` package for making the acquisition of ECWMF data through R possible. 

--- a/inst/doc/mcera5_vignette.Rmd
+++ b/inst/doc/mcera5_vignette.Rmd
@@ -59,9 +59,10 @@ uid <- "*****"
 cds_access_token <- "********-****-****-****-************"
 
 ecmwfr::wf_set_key(user = uid,
-                   key = cds_access_token,
-                   service = "cds")
+                   key = cds_access_token)
 ```
+
+Note that earlier versions of `ecmwfr` required specification of `service` = "cds", but as of August 2024 this is no longer the case (corresponding to the update to the new CDS version).
 
 ## Usage
 

--- a/inst/doc/mcera5_vignette.html
+++ b/inst/doc/mcera5_vignette.html
@@ -441,29 +441,18 @@ request(s) as follows:</p>
 <p>Requests are stored in list format. Each request (divided by year)
 are stored as list objects within the master list:</p>
 <div class="sourceCode" id="cb4"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb4-1"><a href="#cb4-1" tabindex="-1"></a><span class="fu">str</span>(req)</span>
-<span id="cb4-2"><a href="#cb4-2" tabindex="-1"></a><span class="co">#&gt; List of 2</span></span>
+<span id="cb4-2"><a href="#cb4-2" tabindex="-1"></a><span class="co">#&gt; List of 1</span></span>
 <span id="cb4-3"><a href="#cb4-3" tabindex="-1"></a><span class="co">#&gt;  $ :List of 10</span></span>
 <span id="cb4-4"><a href="#cb4-4" tabindex="-1"></a><span class="co">#&gt;   ..$ dataset_short_name: chr &quot;reanalysis-era5-single-levels&quot;</span></span>
 <span id="cb4-5"><a href="#cb4-5" tabindex="-1"></a><span class="co">#&gt;   ..$ product_type      : chr &quot;reanalysis&quot;</span></span>
 <span id="cb4-6"><a href="#cb4-6" tabindex="-1"></a><span class="co">#&gt;   ..$ variable          : chr [1:12] &quot;2m_temperature&quot; &quot;2m_dewpoint_temperature&quot; &quot;surface_pressure&quot; &quot;10m_u_component_of_wind&quot; ...</span></span>
 <span id="cb4-7"><a href="#cb4-7" tabindex="-1"></a><span class="co">#&gt;   ..$ year              : chr &quot;2010&quot;</span></span>
-<span id="cb4-8"><a href="#cb4-8" tabindex="-1"></a><span class="co">#&gt;   ..$ month             : chr &quot;2&quot;</span></span>
+<span id="cb4-8"><a href="#cb4-8" tabindex="-1"></a><span class="co">#&gt;   ..$ month             : chr [1:2] &quot;2&quot; &quot;3&quot;</span></span>
 <span id="cb4-9"><a href="#cb4-9" tabindex="-1"></a><span class="co">#&gt;   ..$ day               : chr [1:31] &quot;01&quot; &quot;02&quot; &quot;03&quot; &quot;04&quot; ...</span></span>
 <span id="cb4-10"><a href="#cb4-10" tabindex="-1"></a><span class="co">#&gt;   ..$ time              : chr [1:24] &quot;00:00&quot; &quot;01:00&quot; &quot;02:00&quot; &quot;03:00&quot; ...</span></span>
 <span id="cb4-11"><a href="#cb4-11" tabindex="-1"></a><span class="co">#&gt;   ..$ area              : chr &quot;51/-4/49/-2&quot;</span></span>
 <span id="cb4-12"><a href="#cb4-12" tabindex="-1"></a><span class="co">#&gt;   ..$ format            : chr &quot;netcdf&quot;</span></span>
-<span id="cb4-13"><a href="#cb4-13" tabindex="-1"></a><span class="co">#&gt;   ..$ target            : chr &quot;era5_-4_-2_49_51_2010_2.nc&quot;</span></span>
-<span id="cb4-14"><a href="#cb4-14" tabindex="-1"></a><span class="co">#&gt;  $ :List of 10</span></span>
-<span id="cb4-15"><a href="#cb4-15" tabindex="-1"></a><span class="co">#&gt;   ..$ dataset_short_name: chr &quot;reanalysis-era5-single-levels&quot;</span></span>
-<span id="cb4-16"><a href="#cb4-16" tabindex="-1"></a><span class="co">#&gt;   ..$ product_type      : chr &quot;reanalysis&quot;</span></span>
-<span id="cb4-17"><a href="#cb4-17" tabindex="-1"></a><span class="co">#&gt;   ..$ variable          : chr [1:12] &quot;2m_temperature&quot; &quot;2m_dewpoint_temperature&quot; &quot;surface_pressure&quot; &quot;10m_u_component_of_wind&quot; ...</span></span>
-<span id="cb4-18"><a href="#cb4-18" tabindex="-1"></a><span class="co">#&gt;   ..$ year              : chr &quot;2010&quot;</span></span>
-<span id="cb4-19"><a href="#cb4-19" tabindex="-1"></a><span class="co">#&gt;   ..$ month             : chr &quot;3&quot;</span></span>
-<span id="cb4-20"><a href="#cb4-20" tabindex="-1"></a><span class="co">#&gt;   ..$ day               : chr [1:31] &quot;01&quot; &quot;02&quot; &quot;03&quot; &quot;04&quot; ...</span></span>
-<span id="cb4-21"><a href="#cb4-21" tabindex="-1"></a><span class="co">#&gt;   ..$ time              : chr [1:24] &quot;00:00&quot; &quot;01:00&quot; &quot;02:00&quot; &quot;03:00&quot; ...</span></span>
-<span id="cb4-22"><a href="#cb4-22" tabindex="-1"></a><span class="co">#&gt;   ..$ area              : chr &quot;51/-4/49/-2&quot;</span></span>
-<span id="cb4-23"><a href="#cb4-23" tabindex="-1"></a><span class="co">#&gt;   ..$ format            : chr &quot;netcdf&quot;</span></span>
-<span id="cb4-24"><a href="#cb4-24" tabindex="-1"></a><span class="co">#&gt;   ..$ target            : chr &quot;era5_-4_-2_49_51_2010_3.nc&quot;</span></span></code></pre></div>
+<span id="cb4-13"><a href="#cb4-13" tabindex="-1"></a><span class="co">#&gt;   ..$ target            : chr &quot;era5_-4_-2_49_51_2010.nc&quot;</span></span></code></pre></div>
 </div>
 <div id="obtaining-data-with-a-request" class="section level4">
 <h4>Obtaining data with a request</h4>
@@ -528,7 +517,11 @@ package, as well as functions from the <code>NicheMapR</code> and
 date ranges within single years, you will need to create a separate data
 frame for each yearly block. For example, if your period of interest
 spans multiple years (and you have used the previous code to download
-multiple .nc files, run this next block of code for each year):</p>
+multiple .nc files, run this next block of code for each year): The
+climate data that are extracted will have different formats according to
+the value provided to <code>format</code>. By default,
+<code>extract_clim()</code> will provide data formatted for
+<code>microclima</code>.</p>
 <div class="sourceCode" id="cb6"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb6-1"><a href="#cb6-1" tabindex="-1"></a><span class="co"># list the path of the .nc file for a given year</span></span>
 <span id="cb6-2"><a href="#cb6-2" tabindex="-1"></a>my_nc <span class="ot">&lt;-</span> <span class="fu">paste0</span>(<span class="fu">getwd</span>(), <span class="st">&quot;/era5_-4_-2_49_51_2010.nc&quot;</span>)</span>
 <span id="cb6-3"><a href="#cb6-3" tabindex="-1"></a></span>
@@ -538,8 +531,10 @@ multiple .nc files, run this next block of code for each year):</p>
 <span id="cb6-7"><a href="#cb6-7" tabindex="-1"></a></span>
 <span id="cb6-8"><a href="#cb6-8" tabindex="-1"></a><span class="co"># gather all hourly variables</span></span>
 <span id="cb6-9"><a href="#cb6-9" tabindex="-1"></a>clim_point <span class="ot">&lt;-</span> <span class="fu">extract_clim</span>(<span class="at">nc =</span> my_nc, <span class="at">long =</span> x, <span class="at">lat =</span> y,</span>
-<span id="cb6-10"><a href="#cb6-10" tabindex="-1"></a>                            <span class="at">start_time =</span> st_time, <span class="at">end_time =</span> en_time)</span>
-<span id="cb6-11"><a href="#cb6-11" tabindex="-1"></a><span class="fu">head</span>(clim_point)</span></code></pre></div>
+<span id="cb6-10"><a href="#cb6-10" tabindex="-1"></a>                          <span class="at">start_time =</span> st_time, <span class="at">end_time =</span> en_time,</span>
+<span id="cb6-11"><a href="#cb6-11" tabindex="-1"></a>                           <span class="at">format =</span> <span class="st">&quot;microclima&quot;</span>)</span>
+<span id="cb6-12"><a href="#cb6-12" tabindex="-1"></a></span>
+<span id="cb6-13"><a href="#cb6-13" tabindex="-1"></a><span class="fu">head</span>(clim_point)</span></code></pre></div>
 <p>In the same fashion, use <code>extract_precip</code> to acquire
 precipitation from your downloaded netCDF file, which also applies an
 inverse distance weighting calculation. By default,
@@ -568,10 +563,21 @@ package:</p>
 <span id="cb8-9"><a href="#cb8-9" tabindex="-1"></a>                             <span class="at">dailyprecip =</span> precip_point, </span>
 <span id="cb8-10"><a href="#cb8-10" tabindex="-1"></a>                             <span class="at">plot.progress=</span> <span class="cn">FALSE</span>)</span></code></pre></div>
 <p>For use of climate data with other microclimate packages, such as
-<code>microclimc</code> and <code>microclimf</code>, you may need to
-reformat the climate data using
-<code>microctools::hourlyncep_convert</code>:</p>
-<div class="sourceCode" id="cb9"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb9-1"><a href="#cb9-1" tabindex="-1"></a>climdata <span class="ot">&lt;-</span> <span class="fu">hourlyncep_convert</span>(<span class="at">climdata =</span> clim_point, <span class="at">lat =</span> y, <span class="at">long =</span> x)</span></code></pre></div>
+<code>microclimc</code> and <code>microclimf</code>, you can specify the
+package name with the argument <code>format</code>:</p>
+<div class="sourceCode" id="cb9"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb9-1"><a href="#cb9-1" tabindex="-1"></a><span class="co"># list the path of the .nc file for a given year</span></span>
+<span id="cb9-2"><a href="#cb9-2" tabindex="-1"></a>my_nc <span class="ot">&lt;-</span> <span class="fu">paste0</span>(<span class="fu">getwd</span>(), <span class="st">&quot;/era5_-4_-2_49_51_2010.nc&quot;</span>)</span>
+<span id="cb9-3"><a href="#cb9-3" tabindex="-1"></a></span>
+<span id="cb9-4"><a href="#cb9-4" tabindex="-1"></a><span class="co"># for a single point (make sure it&#39;s within the bounds of your .nc file)</span></span>
+<span id="cb9-5"><a href="#cb9-5" tabindex="-1"></a>x <span class="ot">&lt;-</span> <span class="sc">-</span><span class="fl">3.654600</span></span>
+<span id="cb9-6"><a href="#cb9-6" tabindex="-1"></a>y <span class="ot">&lt;-</span> <span class="fl">50.640369</span></span>
+<span id="cb9-7"><a href="#cb9-7" tabindex="-1"></a></span>
+<span id="cb9-8"><a href="#cb9-8" tabindex="-1"></a><span class="co"># gather all hourly variables</span></span>
+<span id="cb9-9"><a href="#cb9-9" tabindex="-1"></a>clim_point <span class="ot">&lt;-</span> <span class="fu">extract_clim</span>(<span class="at">nc =</span> my_nc, <span class="at">long =</span> x, <span class="at">lat =</span> y,</span>
+<span id="cb9-10"><a href="#cb9-10" tabindex="-1"></a>                          <span class="at">start_time =</span> st_time, <span class="at">end_time =</span> en_time,</span>
+<span id="cb9-11"><a href="#cb9-11" tabindex="-1"></a>                           <span class="at">format =</span> <span class="st">&quot;microclimc&quot;</span>)</span>
+<span id="cb9-12"><a href="#cb9-12" tabindex="-1"></a></span>
+<span id="cb9-13"><a href="#cb9-13" tabindex="-1"></a><span class="fu">head</span>(clim_point)</span></code></pre></div>
 </div>
 <div id="extracting-climate-data-for-a-spatial-gridarray-using-extract_clima-and-extract_precipa" class="section level4">
 <h4>Extracting climate data for a spatial grid/array using
@@ -579,18 +585,16 @@ extract_clima() and extract_precipa()</h4>
 <p><code>mcera5</code> also can extract ERA5 climate data simultaneously
 across a spatial grid using <code>extract_clima()</code> and
 <code>extract_precipa()</code>, to be provided to functions such as
-<code>microclimf::modelina()</code>. <code>extract_clima()</code> and
-<code>extract_precipa()</code> follow the same format as
+<code>microclimf::runpointmodela()</code>. <code>extract_clima()</code>
+and <code>extract_precipa()</code> follow the same format as
 <code>extract_clim()</code> and <code>extract_precip()</code>, except
 require as input the boundaries of a spatial grid rather than a single
 spatial point. Both functions will return spatRaster layers
-corresponding to the climate variables.</p>
-<p><code>extract_clima</code> also includes the argument
-<code>reformat</code>, which when set to TRUE (the default value) will
-reformat climate data to be used for modeling with
-<code>microclimf</code>. Similarly, <code>extract_precipa</code> has the
-argument <code>convert_daily</code> to sum hourly preicipitation to
-daily precipitation, which is accepted by <code>microclimf</code>
+corresponding to the climate variables, formatted according to what
+package is specified in the argument <code>format</code>.</p>
+<p>The function <code>extract_precipa</code> also has the argument
+<code>convert_daily</code> to sum hourly preicipitation to daily
+precipitation, which is accepted by <code>microclimf</code>
 functions.</p>
 <div class="sourceCode" id="cb10"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb10-1"><a href="#cb10-1" tabindex="-1"></a><span class="co"># list the path of the .nc file for a given year</span></span>
 <span id="cb10-2"><a href="#cb10-2" tabindex="-1"></a>my_nc <span class="ot">&lt;-</span> <span class="fu">paste0</span>(<span class="fu">getwd</span>(), <span class="st">&quot;/era5_-4_-2_49_51_2010.nc&quot;</span>)</span>
@@ -606,7 +610,7 @@ functions.</p>
 <span id="cb10-12"><a href="#cb10-12" tabindex="-1"></a>                          <span class="at">start_time =</span> st_time,</span>
 <span id="cb10-13"><a href="#cb10-13" tabindex="-1"></a>                          <span class="at">end_time =</span> en_time,</span>
 <span id="cb10-14"><a href="#cb10-14" tabindex="-1"></a>                          <span class="at">dtr_cor =</span> <span class="cn">TRUE</span>, <span class="at">dtr_cor_fac =</span> <span class="fl">1.285</span>,</span>
-<span id="cb10-15"><a href="#cb10-15" tabindex="-1"></a>                          <span class="at">reformat =</span> <span class="cn">TRUE</span>)</span>
+<span id="cb10-15"><a href="#cb10-15" tabindex="-1"></a>                          <span class="at">format =</span> <span class="st">&quot;microclimf&quot;</span>)</span>
 <span id="cb10-16"><a href="#cb10-16" tabindex="-1"></a></span>
 <span id="cb10-17"><a href="#cb10-17" tabindex="-1"></a><span class="fu">str</span>(clim_grid)</span>
 <span id="cb10-18"><a href="#cb10-18" tabindex="-1"></a></span>
@@ -619,7 +623,7 @@ functions.</p>
 <div id="acknowledgements" class="section level4">
 <h4>Acknowledgements</h4>
 <p>Thank you to Koen Hufkens, creator of the <code>ecwmfr</code> package
-for making the aquisition of ECWMF data through R possible.</p>
+for making the acquisition of ECWMF data through R possible.</p>
 </div>
 </div>
 

--- a/inst/doc/mcera5_vignette.html
+++ b/inst/doc/mcera5_vignette.html
@@ -384,8 +384,11 @@ ERA5-land.</p></li>
 <span id="cb2-3"><a href="#cb2-3" tabindex="-1"></a>cds_access_token <span class="ot">&lt;-</span> <span class="st">&quot;********-****-****-****-************&quot;</span></span>
 <span id="cb2-4"><a href="#cb2-4" tabindex="-1"></a></span>
 <span id="cb2-5"><a href="#cb2-5" tabindex="-1"></a>ecmwfr<span class="sc">::</span><span class="fu">wf_set_key</span>(<span class="at">user =</span> uid,</span>
-<span id="cb2-6"><a href="#cb2-6" tabindex="-1"></a>                   <span class="at">key =</span> cds_access_token,</span>
-<span id="cb2-7"><a href="#cb2-7" tabindex="-1"></a>                   <span class="at">service =</span> <span class="st">&quot;cds&quot;</span>)</span></code></pre></div>
+<span id="cb2-6"><a href="#cb2-6" tabindex="-1"></a>                   <span class="at">key =</span> cds_access_token)</span></code></pre></div>
+<p>Note that earlier versions of <code>ecmwfr</code> required
+specification of <code>service</code> = “cds”, but as of August 2024
+this is no longer the case (corresponding to the update to the new CDS
+version).</p>
 </div>
 </div>
 <div id="usage" class="section level2">

--- a/man/build_era5_request.Rd
+++ b/man/build_era5_request.Rd
@@ -12,7 +12,8 @@ build_era5_request(
   ymax,
   start_time,
   end_time,
-  outfile_name = "era5_out"
+  outfile_name = "era5_out",
+  by_month = FALSE
 )
 }
 \arguments{
@@ -30,10 +31,13 @@ are required.}
 \item{end_time}{a POSIXlt object indicating the last hour for which data
 are required.}
 
-\item{outfile_name}{character prefix for .nc files when downloaded (the year, month, and file extension is automatically added). Keep in
-mind that you may want to submit multiple (or many) requests, and therefore
-this prefix should adequately describe a unique query (e.g. by its
-spatial or temporal extent).}
+\item{outfile_name}{character prefix for .nc files when downloaded (the year,
+month, and file extension is automatically added). Keep in mind that you may
+want to submit multiple (or many) requests, and therefore this prefix should
+adequately describe a unique query (e.g. by its spatial or temporal extent).}
+
+\item{by_month}{If TRUE, queries each month separately, otherwise queries full year
+at once.}
 }
 \description{
 `build_era5_request` creates a request or set of requests that

--- a/man/extract_clim.Rd
+++ b/man/extract_clim.Rd
@@ -14,7 +14,7 @@ extract_clim(
   d_weight = TRUE,
   dtr_cor = TRUE,
   dtr_cor_fac = 1.285,
-  reformat = NULL
+  format = "microclima"
 )
 }
 \arguments{
@@ -48,11 +48,13 @@ range correction to air temperature values. Default = `TRUE`.}
 correction. Default = 1.285, based on calibration against UK Met Office
 observations.}
 
-\item{reformat}{if set to "micropoint", the function will return a dataframe
-formated for input to runpointmodel from micropoint package}
+\item{format}{specifies what microclimate package extracted climate data will}
 }
 \value{
-a data frame containing hourly values for a suite of climate variables:
+Returns a data frame containing hourly values for a suite of climate
+variables. The returned climate variables depends on the value of argument `format`.
+
+If format is "microclima" or "NicheMapR":
 
 `obs_time` | the date-time (timezone specified in col timezone)
 
@@ -84,12 +86,61 @@ of net long-wave radiation flux and downward long wave radiation flux (unitless)
 `szenith` | Solar zenith angle (degrees from a horizontal plane)
 
 `timezone` | (unitless)
+
+If format is "microclimc":
+
+`obs_time` | POSIXlt object of dates and times
+
+`temp` | temperature (degrees C)
+
+`relhum` | relative humidity (percentage)
+
+`pres` | atmospheric press (kPa)
+
+`swrad` | Total incoming shortwave radiation (W / m^2)
+
+`difrad` | Diffuse radiation (W / m^2)
+
+`skyem` | Sky emissivity (0-1)
+
+`lwdown` | Total downward longwave radiation (W / m^2)
+
+`windspeed` | Wind speed (m/s)
+
+`winddir` | Wind direction (decimal degrees)
+
+`precip` | precipitation (mm)
+
+If format is "micropoint" or "microclimf":
+
+`obs_time` | POSIXlt object of dates and times
+
+`temp` | temperature (degrees C)
+
+`relhum` | relative humidity (percentage)
+
+`pres` | atmospheric press (kPa)
+
+`swdown` | Total incoming shortwave radiation (W / m^2)
+
+`difrad` | Diffuse radiation (W / m^2)
+
+`skyem` | Sky emissivity (0-1)
+
+`lwdown` | Total downward longwave radiation (W / m^2)
+
+`windspeed` | Wind speed (m/s)
+
+`winddir` | Wind direction (decimal degrees)
+
+`precip` | precipitation (mm)
 }
 \description{
 `extract_clim` takes an nc file containing hourly ERA5 climate
 data, and for a given set of coordinates, produces an (optionally) inverse
-distance weighted mean of each variable, ready for use with
-`microclima::runauto`. Also provides the option to implement a diurnal
-temperature range correction to air temperatures.
-If reformat == "micropoint" produces a dataframe ready for use with `micropoint::runpointmodel`.
+distance weighted mean of each variable, ready for use by default with
+`microclima::runauto` and `NicheMapR::micro_era5()`, but also compatible with
+`microclimc`, `microclimf`, and `micropoint` (see argument `format`).
+Also provides the option to implement a diurnal temperature range correction
+to air temperatures.
 }

--- a/man/extract_clim.Rd
+++ b/man/extract_clim.Rd
@@ -14,7 +14,8 @@ extract_clim(
   d_weight = TRUE,
   dtr_cor = TRUE,
   dtr_cor_fac = 1.285,
-  format = "microclima"
+  format = "microclima",
+  cds_version = "new"
 )
 }
 \arguments{
@@ -49,6 +50,11 @@ correction. Default = 1.285, based on calibration against UK Met Office
 observations.}
 
 \item{format}{specifies what microclimate package extracted climate data will}
+
+\item{cds_version}{specifies what version of the CDS (Climate Data Store) the
+ERA5 data were queried from. Either "new" (queries made after Sept 2024) or
+"legacy" (queries made before Sept 2024). This argument will be deprecated in
+the future and only queries from the new CDS will be supported.}
 }
 \value{
 Returns a data frame containing hourly values for a suite of climate

--- a/man/extract_clima.Rd
+++ b/man/extract_clima.Rd
@@ -15,7 +15,7 @@ extract_clima(
   end_time,
   dtr_cor = TRUE,
   dtr_cor_fac = 1.285,
-  reformat = "microclimf"
+  format = "microclimf"
 )
 }
 \arguments{
@@ -49,32 +49,19 @@ range correction to air temperature values. Default = `TRUE`.}
 correction. Default = 1.285, based on calibration against UK Met Office
 observations.}
 
-\item{reformat}{a logical indicating whether to reformat the climate variables
-to be suitable for modeling with microclimf. Default to reformat = `microclimf`}
+\item{format}{specifies what microclimate package extracted climate data will
+be used for. Data will be formatted accordingly. Default is "microclimf".
+Options: "microclima", "NicheMapR", "microclimc", "microclimf", "micropoint".
+Note: of these options, only "microclimf" accepts as input an array of climate
+variables. For all other models you will need to iterate through each spatial
+point to run the model}
 }
 \value{
-a list of wrapped spatRasters containing hourly values for a suite of climate variables. The returned climate variables depends on whether the parameter `reformat` is `microclimf`.
-If `reformat` == "microclimf":
+Returns a list of wrapped spatRasters containing hourly values for a
+suite of climate variables. The returned climate variables depends on the
+value of argument `format`.
 
-`temp` | (degrees celsius)
-
-`relhum` | relative humidity (ercentage)
-
-`pres` | atmospheric press (kPa)
-
-`swdown` | Flux density of total downward shortwave radiation on the horizontal (W / m^2)
-
-`difrad` | Diffuse radiation (W / m^2)
-
-`lwdown` | Flux density of total downward downward radiation (W / m^2)
-
-`windspeed` | (m / s)
-
-`winddir` | wind direction, azimuth (decimal degrees from north)
-
-`precip` | precipitation (mm)
-
-If `reformat` is NULL or some other value:
+If format is "microclima" or "NicheMapR":
 
 `obs_time` | the date-time (timezone specified in col timezone)
 
@@ -104,6 +91,56 @@ of net long-wave radiation flux and downward long wave radiation flux (unitless)
 `rad_dif` | Diffuse normal irradiance (MJ / m2 / hr)
 
 `szenith` | Solar zenith angle (degrees from a horizontal plane)
+
+`timezone` | (unitless)
+
+If format is "microclimc":
+
+`obs_time` | POSIXlt object of dates and times
+
+`temp` | temperature (degrees C)
+
+`relhum` | relative humidity (percentage)
+
+`pres` | atmospheric press (kPa)
+
+`swrad` | Total incoming shortwave radiation (W / m^2)
+
+`difrad` | Diffuse radiation (W / m^2)
+
+`skyem` | Sky emissivity (0-1)
+
+`lwdown` | Total downward longwave radiation (W / m^2)
+
+`windspeed` | Wind speed (m/s)
+
+`winddir` | Wind direction (decimal degrees)
+
+`precip` | precipitation (mm)
+
+If format is "micropoint" or "microclimf":
+
+`obs_time` | POSIXlt object of dates and times
+
+`temp` | temperature (degrees C)
+
+`relhum` | relative humidity (percentage)
+
+`pres` | atmospheric press (kPa)
+
+`swdown` | Total incoming shortwave radiation (W / m^2)
+
+`difrad` | Diffuse radiation (W / m^2)
+
+`skyem` | Sky emissivity (0-1)
+
+`lwdown` | Total downward longwave radiation (W / m^2)
+
+`windspeed` | Wind speed (m/s)
+
+`winddir` | Wind direction (decimal degrees)
+
+`precip` | precipitation (mm)
 }
 \description{
 `extract_clima` takes an nc file containing hourly ERA5 climate

--- a/man/extract_clima.Rd
+++ b/man/extract_clima.Rd
@@ -15,7 +15,8 @@ extract_clima(
   end_time,
   dtr_cor = TRUE,
   dtr_cor_fac = 1.285,
-  format = "microclimf"
+  format = "microclimf",
+  cds_version = "new"
 )
 }
 \arguments{
@@ -55,6 +56,11 @@ Options: "microclima", "NicheMapR", "microclimc", "microclimf", "micropoint".
 Note: of these options, only "microclimf" accepts as input an array of climate
 variables. For all other models you will need to iterate through each spatial
 point to run the model}
+
+\item{cds_version}{specifies what version of the CDS (Climate Data Store) the
+ERA5 data were queried from. Either "new" (queries made after Sept 2024) or
+"legacy" (queries made before Sept 2024). This argument will be deprecated in
+the future and only queries from the new CDS will be supported.}
 }
 \value{
 Returns a list of wrapped spatRasters containing hourly values for a

--- a/man/extract_land_clim.Rd
+++ b/man/extract_land_clim.Rd
@@ -4,7 +4,15 @@
 \alias{extract_land_clim}
 \title{Produces hourly data of ERA5-Land for a single location}
 \usage{
-extract_land_clim(nc, long, lat, start_time, end_time, d_weight = TRUE)
+extract_land_clim(
+  nc,
+  long,
+  lat,
+  start_time,
+  end_time,
+  d_weight = TRUE,
+  cds_version = "new"
+)
 }
 \arguments{
 \item{nc}{character vector containing the path to the nc file. Use the
@@ -29,6 +37,11 @@ data are in UTC by default), but any timezone is accepted.}
 \item{d_weight}{logical value indicating whether to apply inverse distance
 weighting using the 4 closest neighbouring points to the location defined by
 `long` and `lat`. Default = `TRUE`.}
+
+\item{cds_version}{specifies what version of the CDS (Climate Data Store) the
+ERA5 data were queried from. Either "new" (queries made after Sept 2024) or
+"legacy" (queries made before Sept 2024). This argument will be deprecated in
+the future and only queries from the new CDS will be supported.}
 }
 \value{
 a data frame containing hourly values for a suite of climate variables:

--- a/man/extract_precip.Rd
+++ b/man/extract_precip.Rd
@@ -12,7 +12,8 @@ extract_precip(
   start_time,
   end_time,
   d_weight = TRUE,
-  convert_daily = TRUE
+  convert_daily = TRUE,
+  cds_version = "new"
 )
 }
 \arguments{
@@ -42,6 +43,11 @@ weighting using the 4 closest neighbouring points to the location defined by
 \item{convert_daily}{a flag indicating whether the user desires to convert the
 precipitation vector from hourly to daily averages (TRUE) or remain as hourly
 values (FALSE). Only daily precipitation will be accepted by `microclima::runauto`.}
+
+\item{cds_version}{specifies what version of the CDS (Climate Data Store) the
+ERA5 data were queried from. Either "new" (queries made after Sept 2024) or
+"legacy" (queries made before Sept 2024). This argument will be deprecated in
+the future and only queries from the new CDS will be supported.}
 }
 \value{
 a numeric vector of daily or hourly precipitation (mm).

--- a/man/extract_precipa.Rd
+++ b/man/extract_precipa.Rd
@@ -13,7 +13,8 @@ extract_precipa(
   lat_max,
   start_time,
   end_time,
-  convert_daily = TRUE
+  convert_daily = TRUE,
+  cds_version = "new"
 )
 }
 \arguments{
@@ -43,6 +44,11 @@ data are in UTC by default), but any timezone is accepted.}
 \item{convert_daily}{a flag indicating whether the user desires to convert the
  precipitation spatRaster from hourly to daily averages (TRUE) or remain as hourly
 values (FALSE). Only daily precipitation will be accepted by `microclimf::modelina`.}
+
+\item{cds_version}{specifies what version of the CDS (Climate Data Store) the
+ERA5 data were queried from. Either "new" (queries made after Sept 2024) or
+"legacy" (queries made before Sept 2024). This argument will be deprecated in
+the future and only queries from the new CDS will be supported.}
 }
 \value{
 a spatRaster of daily or hourly precipitation (mm).

--- a/vignettes/mcera5_vignette.Rmd
+++ b/vignettes/mcera5_vignette.Rmd
@@ -129,6 +129,7 @@ By default, `extract_clim` applies an inverse distance weighting calculation (co
 Furthermore, `extract_clim` by default applies a diurnal temperature range correction to the data (when `dtr_cor = TRUE` and weighted according to `dtr_cor_fac`). The diurnal temperature ranges of ERA5 are artificially lower in grid cells classed as sea as opposed to land. It may thus be useful to apply a correction if estimates are required for a terrestrial location in predominantly marine grid cells. If applied, an internal function is evoked that uses the land/sea value in the downloaded NetCDF file to adjust temperature values by the factor provided using the formula $DTR_C=DTR[(1-p_l ) C_f+1]$ where $DTR_C$ is the corrected diurnal temperature range, $DTR$ is the diurnal temperature range in the ERA5 dataset, $p_l$ is the proportion of the grid cell that is land and $C_f$ is the correction factor. The default function input value is a correction based on calibration against the UK Met Office 1-km2 gridded dataset of daily maximum and minimum temperatures, itself calibrated and validated against a network of (on average) 1,203 weather stations distributed across the UK. 
 
 Given that `runauto` in the `microclima` package, as well as functions from the `NicheMapR` and `microclimc` microclimate modelling packages, all only accept date ranges within single years, you will need to create a separate data frame for each yearly block. For example, if your period of interest spans multiple years (and you have used the previous code to download multiple .nc files, run this next block of code for each year):
+The climate data that are extracted will have different formats according to the value provided to `format`. By default, `extract_clim()` will provide data formatted for `microclima`.
 
 ```{r process_clim, eval = FALSE}
 # list the path of the .nc file for a given year
@@ -140,10 +141,11 @@ y <- 50.640369
 
 # gather all hourly variables
 clim_point <- extract_clim(nc = my_nc, long = x, lat = y,
-                            start_time = st_time, end_time = en_time)
+                          start_time = st_time, end_time = en_time,
+                           format = "microclima")
+
 head(clim_point)
 ```
-
 
 
 In the same fashion, use `extract_precip` to acquire precipitation from your downloaded netCDF file, which also applies an inverse distance weighting calculation. By default, `extract_precip` sums up hourly ERA5 precipitation to the daily level, which is required for the aforementioned microclimate models. However users can instead receive hourly values by setting `convert_daily = FALSE`. 
@@ -172,18 +174,30 @@ temps <- microclima::runauto(r = r, dstart = "26/02/2010",dfinish = "01/03/2010"
                              plot.progress= FALSE)
 ```
 
-For use of climate data with other microclimate packages, such as `microclimc` and `microclimf`, you may need to reformat the climate data using `microctools::hourlyncep_convert`:
+For use of climate data with other microclimate packages, such as `microclimc` and `microclimf`, you can specify the package name with the argument `format`:
 
-```{r hourlyncep_convert_example, eval = FALSE}
-climdata <- hourlyncep_convert(climdata = clim_point, lat = y, long = x)
+```{r process_clim_microclimc, eval = FALSE}
+# list the path of the .nc file for a given year
+my_nc <- paste0(getwd(), "/era5_-4_-2_49_51_2010.nc")
+
+# for a single point (make sure it's within the bounds of your .nc file)
+x <- -3.654600
+y <- 50.640369
+
+# gather all hourly variables
+clim_point <- extract_clim(nc = my_nc, long = x, lat = y,
+                          start_time = st_time, end_time = en_time,
+                           format = "microclimc")
+
+head(clim_point)
 ```
 
 #### Extracting climate data for a spatial grid/array using extract_clima() and extract_precipa()
 
 
-`mcera5` also can extract ERA5 climate data simultaneously across a spatial grid using `extract_clima()` and `extract_precipa()`, to be provided to functions such as `microclimf::modelina()`. `extract_clima()` and `extract_precipa()` follow the same format as `extract_clim()` and `extract_precip()`, except require as input the boundaries of a spatial grid rather than a single spatial point. Both functions will return spatRaster layers corresponding to the climate variables.
+`mcera5` also can extract ERA5 climate data simultaneously across a spatial grid using `extract_clima()` and `extract_precipa()`, to be provided to functions such as `microclimf::runpointmodela()`. `extract_clima()` and `extract_precipa()` follow the same format as `extract_clim()` and `extract_precip()`, except require as input the boundaries of a spatial grid rather than a single spatial point. Both functions will return spatRaster layers corresponding to the climate variables, formatted according to what package is specified in the argument `format`.
 
-`extract_clima` also includes the argument `reformat`, which when set to TRUE (the default value) will reformat climate data to be used for modeling with `microclimf`. Similarly, `extract_precipa` has the argument `convert_daily` to sum hourly preicipitation to daily precipitation, which is accepted by `microclimf` functions.
+The function `extract_precipa` also has the argument `convert_daily` to sum hourly preicipitation to daily precipitation, which is accepted by `microclimf` functions.
 
 ```{r process_clima, eval = FALSE}
 # list the path of the .nc file for a given year
@@ -200,7 +214,7 @@ clim_grid <- extract_clima(nc, long_min, long_max, lat_min, lat_max,
                           start_time = st_time,
                           end_time = en_time,
                           dtr_cor = TRUE, dtr_cor_fac = 1.285,
-                          reformat = TRUE)
+                          format = "microclimf")
 
 str(clim_grid)
 
@@ -215,4 +229,4 @@ str(precip_grid)
 
 #### Acknowledgements
 
-Thank you to Koen Hufkens, creator of the `ecwmfr` package for making the aquisition of ECWMF data through R possible. 
+Thank you to Koen Hufkens, creator of the `ecwmfr` package for making the acquisition of ECWMF data through R possible. 

--- a/vignettes/mcera5_vignette.Rmd
+++ b/vignettes/mcera5_vignette.Rmd
@@ -59,9 +59,10 @@ uid <- "*****"
 cds_access_token <- "********-****-****-****-************"
 
 ecmwfr::wf_set_key(user = uid,
-                   key = cds_access_token,
-                   service = "cds")
+                   key = cds_access_token)
 ```
+
+Note that earlier versions of `ecmwfr` required specification of `service` = "cds", but as of August 2024 this is no longer the case (corresponding to the update to the new CDS version).
 
 ## Usage
 

--- a/vignettes/mcera5_vignette.html
+++ b/vignettes/mcera5_vignette.html
@@ -441,29 +441,18 @@ request(s) as follows:</p>
 <p>Requests are stored in list format. Each request (divided by year)
 are stored as list objects within the master list:</p>
 <div class="sourceCode" id="cb4"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb4-1"><a href="#cb4-1" tabindex="-1"></a><span class="fu">str</span>(req)</span>
-<span id="cb4-2"><a href="#cb4-2" tabindex="-1"></a><span class="co">#&gt; List of 2</span></span>
+<span id="cb4-2"><a href="#cb4-2" tabindex="-1"></a><span class="co">#&gt; List of 1</span></span>
 <span id="cb4-3"><a href="#cb4-3" tabindex="-1"></a><span class="co">#&gt;  $ :List of 10</span></span>
 <span id="cb4-4"><a href="#cb4-4" tabindex="-1"></a><span class="co">#&gt;   ..$ dataset_short_name: chr &quot;reanalysis-era5-single-levels&quot;</span></span>
 <span id="cb4-5"><a href="#cb4-5" tabindex="-1"></a><span class="co">#&gt;   ..$ product_type      : chr &quot;reanalysis&quot;</span></span>
 <span id="cb4-6"><a href="#cb4-6" tabindex="-1"></a><span class="co">#&gt;   ..$ variable          : chr [1:12] &quot;2m_temperature&quot; &quot;2m_dewpoint_temperature&quot; &quot;surface_pressure&quot; &quot;10m_u_component_of_wind&quot; ...</span></span>
 <span id="cb4-7"><a href="#cb4-7" tabindex="-1"></a><span class="co">#&gt;   ..$ year              : chr &quot;2010&quot;</span></span>
-<span id="cb4-8"><a href="#cb4-8" tabindex="-1"></a><span class="co">#&gt;   ..$ month             : chr &quot;2&quot;</span></span>
+<span id="cb4-8"><a href="#cb4-8" tabindex="-1"></a><span class="co">#&gt;   ..$ month             : chr [1:2] &quot;2&quot; &quot;3&quot;</span></span>
 <span id="cb4-9"><a href="#cb4-9" tabindex="-1"></a><span class="co">#&gt;   ..$ day               : chr [1:31] &quot;01&quot; &quot;02&quot; &quot;03&quot; &quot;04&quot; ...</span></span>
 <span id="cb4-10"><a href="#cb4-10" tabindex="-1"></a><span class="co">#&gt;   ..$ time              : chr [1:24] &quot;00:00&quot; &quot;01:00&quot; &quot;02:00&quot; &quot;03:00&quot; ...</span></span>
 <span id="cb4-11"><a href="#cb4-11" tabindex="-1"></a><span class="co">#&gt;   ..$ area              : chr &quot;51/-4/49/-2&quot;</span></span>
 <span id="cb4-12"><a href="#cb4-12" tabindex="-1"></a><span class="co">#&gt;   ..$ format            : chr &quot;netcdf&quot;</span></span>
-<span id="cb4-13"><a href="#cb4-13" tabindex="-1"></a><span class="co">#&gt;   ..$ target            : chr &quot;era5_-4_-2_49_51_2010_2.nc&quot;</span></span>
-<span id="cb4-14"><a href="#cb4-14" tabindex="-1"></a><span class="co">#&gt;  $ :List of 10</span></span>
-<span id="cb4-15"><a href="#cb4-15" tabindex="-1"></a><span class="co">#&gt;   ..$ dataset_short_name: chr &quot;reanalysis-era5-single-levels&quot;</span></span>
-<span id="cb4-16"><a href="#cb4-16" tabindex="-1"></a><span class="co">#&gt;   ..$ product_type      : chr &quot;reanalysis&quot;</span></span>
-<span id="cb4-17"><a href="#cb4-17" tabindex="-1"></a><span class="co">#&gt;   ..$ variable          : chr [1:12] &quot;2m_temperature&quot; &quot;2m_dewpoint_temperature&quot; &quot;surface_pressure&quot; &quot;10m_u_component_of_wind&quot; ...</span></span>
-<span id="cb4-18"><a href="#cb4-18" tabindex="-1"></a><span class="co">#&gt;   ..$ year              : chr &quot;2010&quot;</span></span>
-<span id="cb4-19"><a href="#cb4-19" tabindex="-1"></a><span class="co">#&gt;   ..$ month             : chr &quot;3&quot;</span></span>
-<span id="cb4-20"><a href="#cb4-20" tabindex="-1"></a><span class="co">#&gt;   ..$ day               : chr [1:31] &quot;01&quot; &quot;02&quot; &quot;03&quot; &quot;04&quot; ...</span></span>
-<span id="cb4-21"><a href="#cb4-21" tabindex="-1"></a><span class="co">#&gt;   ..$ time              : chr [1:24] &quot;00:00&quot; &quot;01:00&quot; &quot;02:00&quot; &quot;03:00&quot; ...</span></span>
-<span id="cb4-22"><a href="#cb4-22" tabindex="-1"></a><span class="co">#&gt;   ..$ area              : chr &quot;51/-4/49/-2&quot;</span></span>
-<span id="cb4-23"><a href="#cb4-23" tabindex="-1"></a><span class="co">#&gt;   ..$ format            : chr &quot;netcdf&quot;</span></span>
-<span id="cb4-24"><a href="#cb4-24" tabindex="-1"></a><span class="co">#&gt;   ..$ target            : chr &quot;era5_-4_-2_49_51_2010_3.nc&quot;</span></span></code></pre></div>
+<span id="cb4-13"><a href="#cb4-13" tabindex="-1"></a><span class="co">#&gt;   ..$ target            : chr &quot;era5_-4_-2_49_51_2010.nc&quot;</span></span></code></pre></div>
 </div>
 <div id="obtaining-data-with-a-request" class="section level4">
 <h4>Obtaining data with a request</h4>
@@ -528,7 +517,11 @@ package, as well as functions from the <code>NicheMapR</code> and
 date ranges within single years, you will need to create a separate data
 frame for each yearly block. For example, if your period of interest
 spans multiple years (and you have used the previous code to download
-multiple .nc files, run this next block of code for each year):</p>
+multiple .nc files, run this next block of code for each year): The
+climate data that are extracted will have different formats according to
+the value provided to <code>format</code>. By default,
+<code>extract_clim()</code> will provide data formatted for
+<code>microclima</code>.</p>
 <div class="sourceCode" id="cb6"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb6-1"><a href="#cb6-1" tabindex="-1"></a><span class="co"># list the path of the .nc file for a given year</span></span>
 <span id="cb6-2"><a href="#cb6-2" tabindex="-1"></a>my_nc <span class="ot">&lt;-</span> <span class="fu">paste0</span>(<span class="fu">getwd</span>(), <span class="st">&quot;/era5_-4_-2_49_51_2010.nc&quot;</span>)</span>
 <span id="cb6-3"><a href="#cb6-3" tabindex="-1"></a></span>
@@ -538,8 +531,10 @@ multiple .nc files, run this next block of code for each year):</p>
 <span id="cb6-7"><a href="#cb6-7" tabindex="-1"></a></span>
 <span id="cb6-8"><a href="#cb6-8" tabindex="-1"></a><span class="co"># gather all hourly variables</span></span>
 <span id="cb6-9"><a href="#cb6-9" tabindex="-1"></a>clim_point <span class="ot">&lt;-</span> <span class="fu">extract_clim</span>(<span class="at">nc =</span> my_nc, <span class="at">long =</span> x, <span class="at">lat =</span> y,</span>
-<span id="cb6-10"><a href="#cb6-10" tabindex="-1"></a>                            <span class="at">start_time =</span> st_time, <span class="at">end_time =</span> en_time)</span>
-<span id="cb6-11"><a href="#cb6-11" tabindex="-1"></a><span class="fu">head</span>(clim_point)</span></code></pre></div>
+<span id="cb6-10"><a href="#cb6-10" tabindex="-1"></a>                          <span class="at">start_time =</span> st_time, <span class="at">end_time =</span> en_time,</span>
+<span id="cb6-11"><a href="#cb6-11" tabindex="-1"></a>                           <span class="at">format =</span> <span class="st">&quot;microclima&quot;</span>)</span>
+<span id="cb6-12"><a href="#cb6-12" tabindex="-1"></a></span>
+<span id="cb6-13"><a href="#cb6-13" tabindex="-1"></a><span class="fu">head</span>(clim_point)</span></code></pre></div>
 <p>In the same fashion, use <code>extract_precip</code> to acquire
 precipitation from your downloaded netCDF file, which also applies an
 inverse distance weighting calculation. By default,
@@ -568,10 +563,21 @@ package:</p>
 <span id="cb8-9"><a href="#cb8-9" tabindex="-1"></a>                             <span class="at">dailyprecip =</span> precip_point, </span>
 <span id="cb8-10"><a href="#cb8-10" tabindex="-1"></a>                             <span class="at">plot.progress=</span> <span class="cn">FALSE</span>)</span></code></pre></div>
 <p>For use of climate data with other microclimate packages, such as
-<code>microclimc</code> and <code>microclimf</code>, you may need to
-reformat the climate data using
-<code>microctools::hourlyncep_convert</code>:</p>
-<div class="sourceCode" id="cb9"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb9-1"><a href="#cb9-1" tabindex="-1"></a>climdata <span class="ot">&lt;-</span> <span class="fu">hourlyncep_convert</span>(<span class="at">climdata =</span> clim_point, <span class="at">lat =</span> y, <span class="at">long =</span> x)</span></code></pre></div>
+<code>microclimc</code> and <code>microclimf</code>, you can specify the
+package name with the argument <code>format</code>:</p>
+<div class="sourceCode" id="cb9"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb9-1"><a href="#cb9-1" tabindex="-1"></a><span class="co"># list the path of the .nc file for a given year</span></span>
+<span id="cb9-2"><a href="#cb9-2" tabindex="-1"></a>my_nc <span class="ot">&lt;-</span> <span class="fu">paste0</span>(<span class="fu">getwd</span>(), <span class="st">&quot;/era5_-4_-2_49_51_2010.nc&quot;</span>)</span>
+<span id="cb9-3"><a href="#cb9-3" tabindex="-1"></a></span>
+<span id="cb9-4"><a href="#cb9-4" tabindex="-1"></a><span class="co"># for a single point (make sure it&#39;s within the bounds of your .nc file)</span></span>
+<span id="cb9-5"><a href="#cb9-5" tabindex="-1"></a>x <span class="ot">&lt;-</span> <span class="sc">-</span><span class="fl">3.654600</span></span>
+<span id="cb9-6"><a href="#cb9-6" tabindex="-1"></a>y <span class="ot">&lt;-</span> <span class="fl">50.640369</span></span>
+<span id="cb9-7"><a href="#cb9-7" tabindex="-1"></a></span>
+<span id="cb9-8"><a href="#cb9-8" tabindex="-1"></a><span class="co"># gather all hourly variables</span></span>
+<span id="cb9-9"><a href="#cb9-9" tabindex="-1"></a>clim_point <span class="ot">&lt;-</span> <span class="fu">extract_clim</span>(<span class="at">nc =</span> my_nc, <span class="at">long =</span> x, <span class="at">lat =</span> y,</span>
+<span id="cb9-10"><a href="#cb9-10" tabindex="-1"></a>                          <span class="at">start_time =</span> st_time, <span class="at">end_time =</span> en_time,</span>
+<span id="cb9-11"><a href="#cb9-11" tabindex="-1"></a>                           <span class="at">format =</span> <span class="st">&quot;microclimc&quot;</span>)</span>
+<span id="cb9-12"><a href="#cb9-12" tabindex="-1"></a></span>
+<span id="cb9-13"><a href="#cb9-13" tabindex="-1"></a><span class="fu">head</span>(clim_point)</span></code></pre></div>
 </div>
 <div id="extracting-climate-data-for-a-spatial-gridarray-using-extract_clima-and-extract_precipa" class="section level4">
 <h4>Extracting climate data for a spatial grid/array using
@@ -579,18 +585,16 @@ extract_clima() and extract_precipa()</h4>
 <p><code>mcera5</code> also can extract ERA5 climate data simultaneously
 across a spatial grid using <code>extract_clima()</code> and
 <code>extract_precipa()</code>, to be provided to functions such as
-<code>microclimf::modelina()</code>. <code>extract_clima()</code> and
-<code>extract_precipa()</code> follow the same format as
+<code>microclimf::runpointmodela()</code>. <code>extract_clima()</code>
+and <code>extract_precipa()</code> follow the same format as
 <code>extract_clim()</code> and <code>extract_precip()</code>, except
 require as input the boundaries of a spatial grid rather than a single
 spatial point. Both functions will return spatRaster layers
-corresponding to the climate variables.</p>
-<p><code>extract_clima</code> also includes the argument
-<code>reformat</code>, which when set to TRUE (the default value) will
-reformat climate data to be used for modeling with
-<code>microclimf</code>. Similarly, <code>extract_precipa</code> has the
-argument <code>convert_daily</code> to sum hourly preicipitation to
-daily precipitation, which is accepted by <code>microclimf</code>
+corresponding to the climate variables, formatted according to what
+package is specified in the argument <code>format</code>.</p>
+<p>The function <code>extract_precipa</code> also has the argument
+<code>convert_daily</code> to sum hourly preicipitation to daily
+precipitation, which is accepted by <code>microclimf</code>
 functions.</p>
 <div class="sourceCode" id="cb10"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb10-1"><a href="#cb10-1" tabindex="-1"></a><span class="co"># list the path of the .nc file for a given year</span></span>
 <span id="cb10-2"><a href="#cb10-2" tabindex="-1"></a>my_nc <span class="ot">&lt;-</span> <span class="fu">paste0</span>(<span class="fu">getwd</span>(), <span class="st">&quot;/era5_-4_-2_49_51_2010.nc&quot;</span>)</span>
@@ -606,7 +610,7 @@ functions.</p>
 <span id="cb10-12"><a href="#cb10-12" tabindex="-1"></a>                          <span class="at">start_time =</span> st_time,</span>
 <span id="cb10-13"><a href="#cb10-13" tabindex="-1"></a>                          <span class="at">end_time =</span> en_time,</span>
 <span id="cb10-14"><a href="#cb10-14" tabindex="-1"></a>                          <span class="at">dtr_cor =</span> <span class="cn">TRUE</span>, <span class="at">dtr_cor_fac =</span> <span class="fl">1.285</span>,</span>
-<span id="cb10-15"><a href="#cb10-15" tabindex="-1"></a>                          <span class="at">reformat =</span> <span class="cn">TRUE</span>)</span>
+<span id="cb10-15"><a href="#cb10-15" tabindex="-1"></a>                          <span class="at">format =</span> <span class="st">&quot;microclimf&quot;</span>)</span>
 <span id="cb10-16"><a href="#cb10-16" tabindex="-1"></a></span>
 <span id="cb10-17"><a href="#cb10-17" tabindex="-1"></a><span class="fu">str</span>(clim_grid)</span>
 <span id="cb10-18"><a href="#cb10-18" tabindex="-1"></a></span>
@@ -619,7 +623,7 @@ functions.</p>
 <div id="acknowledgements" class="section level4">
 <h4>Acknowledgements</h4>
 <p>Thank you to Koen Hufkens, creator of the <code>ecwmfr</code> package
-for making the aquisition of ECWMF data through R possible.</p>
+for making the acquisition of ECWMF data through R possible.</p>
 </div>
 </div>
 

--- a/vignettes/mcera5_vignette.html
+++ b/vignettes/mcera5_vignette.html
@@ -384,8 +384,11 @@ ERA5-land.</p></li>
 <span id="cb2-3"><a href="#cb2-3" tabindex="-1"></a>cds_access_token <span class="ot">&lt;-</span> <span class="st">&quot;********-****-****-****-************&quot;</span></span>
 <span id="cb2-4"><a href="#cb2-4" tabindex="-1"></a></span>
 <span id="cb2-5"><a href="#cb2-5" tabindex="-1"></a>ecmwfr<span class="sc">::</span><span class="fu">wf_set_key</span>(<span class="at">user =</span> uid,</span>
-<span id="cb2-6"><a href="#cb2-6" tabindex="-1"></a>                   <span class="at">key =</span> cds_access_token,</span>
-<span id="cb2-7"><a href="#cb2-7" tabindex="-1"></a>                   <span class="at">service =</span> <span class="st">&quot;cds&quot;</span>)</span></code></pre></div>
+<span id="cb2-6"><a href="#cb2-6" tabindex="-1"></a>                   <span class="at">key =</span> cds_access_token)</span></code></pre></div>
+<p>Note that earlier versions of <code>ecmwfr</code> required
+specification of <code>service</code> = “cds”, but as of August 2024
+this is no longer the case (corresponding to the update to the new CDS
+version).</p>
 </div>
 </div>
 <div id="usage" class="section level2">


### PR DESCRIPTION
Two primary bodies of changes:
1. The transition that ECMWF has undertaken to a [new Climate Data Store](https://cds.climate.copernicus.eu/) has required a lot of development and fixes. While new ERA5 and ERA5-land queries can only be made via the new CDS, users may still have ERA5 data on their machines that they queried from the old CDS. The argument `cds_version` added to many user-facing and internal functions only specification of which CDS version the ERA5 data were queried from.
2. As `microclimf` and `micropoint` continue to be developed, additional functionality to supply climate data for these packages is necessary.  However other microclimate packages (namely `microclima`, which `NicheMapR::micro_era5()` is still reliant on) necessitate climate data formatted differently. The argument `format` is now added to many user-facing and internal functions to specify how the extracted climate data should be formatted, corresponding to what R package they will be interoperable with.