### PR TITLE
wf_request call to remove user parameter

### DIFF
--- a/R/request_era5.R
+++ b/R/request_era5.R
@@ -32,8 +32,7 @@ request_era5 <- function(request, uid, out_path, overwrite = FALSE,
       }
     }
 
-    ecmwfr::wf_request(user = as.character(uid),
-                       request = request[[req]],
+    ecmwfr::wf_request(request = request[[req]],
                        transfer = TRUE,
                        path = out_path,
                        verbose = TRUE,


### PR DESCRIPTION
Remove user parameter to prevent errors with wf_request. Refer to ecmwfr documentation 

Original call
`wf_request(request,
  user = "your_id")`

New call
`wf_request(request)`